### PR TITLE
Kernel module fix

### DIFF
--- a/modules/S25_kernel_check.sh
+++ b/modules/S25_kernel_check.sh
@@ -119,14 +119,16 @@ analyze_kernel_module()
   sub_module_title "Analyze kernel modules"
 
   local MOD_DATA
-  MOD_DATA="$(find "$FIRMWARE_PATH" -iname "*.ko" -execdir modinfo {} \; 2> /dev/null | grep -E "filename|license" | cut -d: -f1,2 | \
-  sed ':a;N;$!ba;s/\nlicense//g' | sed 's/filename: //' | sed 's/ //g' | sed 's/:/||license:/' 2> /dev/null)"
+  mapfile -t MOD_DATA < <(find "$FIRMWARE_PATH" -iname "*.ko" -execdir modinfo {} \; 2> /dev/null | grep -E "filename|license" | cut -d: -f1,2 | \
+  sed ':a;N;$!ba;s/\nlicense//g' | sed 's/filename: //' | sed 's/ //g' | sed 's/:/||license:/' 2> /dev/null)
+
   local MOD_COUNT
   MOD_COUNT=$(echo "$MOD_DATA" | wc -l)
   print_output "[*] Found ""$MOD_COUNT"" kernel modules"
 
   for LINE in $MOD_DATA ; do
     local M_PATH
+    echo $LINE
     M_PATH="$( echo "$LINE" | cut -d '|' -f 1 )"
     local LICENSE
     LICENSE="$( echo "$LINE" | cut -d '|' -f 3 | sed 's/license:/License: /' )"

--- a/modules/S25_kernel_check.sh
+++ b/modules/S25_kernel_check.sh
@@ -122,13 +122,13 @@ analyze_kernel_module()
   mapfile -t MOD_DATA < <(find "$FIRMWARE_PATH" -iname "*.ko" -execdir modinfo {} \; 2> /dev/null | grep -E "filename|license" | cut -d: -f1,2 | \
   sed ':a;N;$!ba;s/\nlicense//g' | sed 's/filename: //' | sed 's/ //g' | sed 's/:/||license:/' 2> /dev/null)
 
-  local MOD_COUNT
-  MOD_COUNT=$(echo "$MOD_DATA" | wc -l)
-  print_output "[*] Found ""$MOD_COUNT"" kernel modules"
+  #local MOD_COUNT
+  #MOD_COUNT=$(echo "$MOD_DATA" | wc -l)
+  #print_output "[*] Found ""$MOD_COUNT"" kernel modules"
+  print_output "[*] Found ""${#MOD_DATA[@]}"" kernel modules"
 
-  for LINE in $MOD_DATA ; do
+  for LINE in "${MOD_DATA[@]}" ; do
     local M_PATH
-    echo $LINE
     M_PATH="$( echo "$LINE" | cut -d '|' -f 1 )"
     local LICENSE
     LICENSE="$( echo "$LINE" | cut -d '|' -f 3 | sed 's/license:/License: /' )"

--- a/modules/S25_kernel_check.sh
+++ b/modules/S25_kernel_check.sh
@@ -122,9 +122,6 @@ analyze_kernel_module()
   mapfile -t MOD_DATA < <(find "$FIRMWARE_PATH" -iname "*.ko" -execdir modinfo {} \; 2> /dev/null | grep -E "filename|license" | cut -d: -f1,2 | \
   sed ':a;N;$!ba;s/\nlicense//g' | sed 's/filename: //' | sed 's/ //g' | sed 's/:/||license:/' 2> /dev/null)
 
-  #local MOD_COUNT
-  #MOD_COUNT=$(echo "$MOD_DATA" | wc -l)
-  #print_output "[*] Found ""$MOD_COUNT"" kernel modules"
   print_output "[*] Found ""${#MOD_DATA[@]}"" kernel modules"
 
   for LINE in "${MOD_DATA[@]}" ; do


### PR DESCRIPTION
During testing the following issue was found and fixed:

```[-] Found kernel module    - STRIPPED
./helpers/print.sh: Zeile 92: /usr/bin/tee: Die Argumentliste ist zu lang
./helpers/print.sh: Zeile 253: /usr/bin/sed: Die Argumentliste ist zu lang
./helpers/print.sh: Zeile 254: /usr/bin/sed: Die Argumentliste ist zu lang
./helpers/print.sh: Zeile 255: /usr/bin/sed: Die Argumentliste ist zu lang
./helpers/print.sh: Zeile 252: /usr/bin/sed: Die Argumentliste ist zu lang
./modules/S25_kernel_check.sh: Zeile 130: /usr/bin/cut: Die Argumentliste ist zu lang
./modules/S25_kernel_check.sh: Zeile 132: /usr/bin/cut: Die Argumentliste ist zu lang
./modules/S25_kernel_check.sh: Zeile 132: /usr/bin/sed: Die Argumentliste ist zu lang
./modules/S25_kernel_check.sh: Zeile 133: /usr/bin/grep: Die Argumentliste ist zu lang
./helpers/print.sh: Zeile 81: /usr/bin/cut: Die Argumentliste ist zu lang
```