### PR TITLE
Version strip down from linux kernel failed

### DIFF
--- a/modules/S25_kernel_check.sh
+++ b/modules/S25_kernel_check.sh
@@ -97,6 +97,7 @@ get_kernel_vulns()
       local KV
       KV=$(echo "$VER" | tr "-" " ")
       KV=$(echo "$KV" | tr "+" " ")
+      KV=$(echo "$KV" | tr "_" " ")
       KV=$(echo "$KV" | cut -d\  -f1)
 
       while echo "$KV" | grep -q '[a-zA-Z]'; do


### PR DESCRIPTION
kernel version strip down failed on kernel version strings like 2.6.18_haha-test123_123-test_test_xa-abc

![image](https://user-images.githubusercontent.com/497520/100750661-a5145580-33e6-11eb-9abc-70b6acdd71aa.png)
