### PR TITLE
FACT-extractor as a second extractor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   emba:
     build: .
     volumes:
-        - ${FIRMWARE}:/firmware
-        - ${LOG}:/log
+        - ${FIRMWARE}/:/firmware
+        - ${LOG}/:/log
         - /var/run/docker.sock:/var/run/docker.sock
     network_mode: "host"
     

--- a/emba.sh
+++ b/emba.sh
@@ -69,6 +69,7 @@ main()
   export ONLY_DEP=0             # test only dependency
   export USE_DOCKER=0
   export IN_DOCKER=0
+  export FACT_EXTRACTOR=0
   export FORCE=0
   export LOG_GREP=0
   export QEMULATION=0

--- a/helpers/dependency_check.sh
+++ b/helpers/dependency_check.sh
@@ -281,6 +281,29 @@ dependency_check()
       echo -e "$ORANGE""not checked (disabled)""$NC"
     fi
 
+    print_output "    docker - \\c" "no_log"
+    if ! command -v docker > /dev/null ; then
+      echo -e "$RED""not ok""$NC"
+      echo -e "$RED""    missing docker ... check your installation""$NC"
+      echo -e "$RED""    you can run the installer.sh script or install it manually""$NC"
+      FACT_EXTRACTOR=0
+    else
+      echo -e "$GREEN""ok""$NC"
+      print_output "    fact-extractor - \\c" "no_log"
+      if docker images | grep -q fact_extractor ; then
+        echo -e "$GREEN""ok""$NC"
+        FACT_EXTRACTOR=1
+      else
+        echo -e "$RED""not ok""$NC"
+        echo -e "$RED""    missing docker image fact-extractor ... check your installation""$NC"
+        echo -e "$RED""      https://github.com/fkie-cad/fact_extractor""$NC"
+        echo -e "$RED""    you can run the installer.sh script or pull it manually:""$NC"
+        echo -e "$RED""      docker pull fkiecad/fact_extractor""$NC"
+        FACT_EXTRACTOR=0
+      fi
+    fi
+    export FACT_EXTRACTOR
+ 
     print_output "    fdtdump - \\c" "no_log"
     if ! command -v fdtdump > /dev/null ; then
       echo -e "$RED""not ok""$NC"

--- a/installer.sh
+++ b/installer.sh
@@ -278,6 +278,10 @@ case ${ANSWER:0:1} in
     if [[ "$(docker images -q fkiecad/fact_extractor:latest 2> /dev/null)" == "" ]] ; then
       docker pull fkiecad/fact_extractor:latest
     fi
+    if ! [[ -f "./external/extract.py" ]]; then
+      download_file "FACT-extract" "https://raw.githubusercontent.com/fkie-cad/fact_extractor/master/extract.py" "external/extract.py"
+      chmod +x ./external/extract.py
+    fi
   ;;
 esac
 

--- a/installer.sh
+++ b/installer.sh
@@ -257,7 +257,7 @@ else
   echo -e "\\n""$ORANGE""$BOLD""fkiecad/fact_extractor docker image""$NC"
   echo "Download-Size: ~1500 MB"
 fi
-if [[ "$(docker images -q fkiecad/cwe_checker:latest 2> /dev/null)" == "" ]] ; then
+if [[ "$(docker images -q fkiecad/fact_extractor:latest 2> /dev/null)" == "" ]] ; then
   echo -e "$ORANGE""fkiecad/fact_extractor docker image will be downloaded""$NC"
 else
   echo -e "$ORANGE""fkiecad/fact_extractor docker image is already downloaded""$NC"
@@ -275,8 +275,8 @@ case ${ANSWER:0:1} in
     for APP in "${INSTALL_APP_LIST[@]}" ; do
       apt-get install "$APP" -y
     done
-    if [[ "$(docker images -q fkiecad/cwe_checker:latest 2> /dev/null)" == "" ]] ; then
-      docker pull fkiecad/cwe_checker:latest
+    if [[ "$(docker images -q fkiecad/fact_extractor:latest 2> /dev/null)" == "" ]] ; then
+      docker pull fkiecad/fact_extractor:latest
     fi
   ;;
 esac

--- a/installer.sh
+++ b/installer.sh
@@ -241,6 +241,47 @@ case ${ANSWER:0:1} in
   ;;
 esac
 
+# FACT-extractor docker
+
+echo -e "\\nWith emba you can automatically use FACT-extractor as a second extraction tool. Docker and the fact_extractor from fkiecad are required for this."
+INSTALL_APP_LIST=()
+print_tool_info "docker.io" 0 "docker"
+
+if command -v docker > /dev/null ; then
+  echo -e "\\n""$ORANGE""$BOLD""fkiecad/fact_extractor docker image""$NC"
+  export DOCKER_CLI_EXPERIMENTAL=enabled
+  f="$(docker manifest inspect fkiecad/fact_extractor:latest | grep "size" | sed -e 's/[^0-9 ]//g')"
+  echo "Download-Size : ""$(($(( ${f//$'\n'/+} ))/1048576))"" MB"
+  export DOCKER_CLI_EXPERIMENTAL=disabled
+else
+  echo -e "\\n""$ORANGE""$BOLD""fkiecad/fact_extractor docker image""$NC"
+  echo "Download-Size: ~1500 MB"
+fi
+if [[ "$(docker images -q fkiecad/cwe_checker:latest 2> /dev/null)" == "" ]] ; then
+  echo -e "$ORANGE""fkiecad/fact_extractor docker image will be downloaded""$NC"
+else
+  echo -e "$ORANGE""fkiecad/fact_extractor docker image is already downloaded""$NC"
+fi
+
+if [[ "$FORCE" -eq 0 ]] ; then
+  echo -e "\\n""$MAGENTA""$BOLD""Do you want to install Docker (if not already on the system) and download the image?""$NC"
+  read -p "(y/N)" -r ANSWER
+else
+  echo -e "\\n""$MAGENTA""$BOLD""Docker will be installed (if not already on the system) and the image be downloaded!""$NC"
+  ANSWER=("y")
+fi
+case ${ANSWER:0:1} in
+  y|Y )
+    for APP in "${INSTALL_APP_LIST[@]}" ; do
+      apt-get install "$APP" -y
+    done
+    if [[ "$(docker images -q fkiecad/cwe_checker:latest 2> /dev/null)" == "" ]] ; then
+      docker pull fkiecad/cwe_checker:latest
+    fi
+  ;;
+esac
+
+
 # open source tools from github
 
 echo -e "\\nWe use a few well-known open source tools in emba, for example checksec."

--- a/modules/F19_cve_aggregator.sh
+++ b/modules/F19_cve_aggregator.sh
@@ -423,7 +423,7 @@ generate_cve_details() {
       if command -v cve_searchsploit > /dev/null ; then
         # if no exploit was found lets talk to exploitdb:
         if [[ "$EXPLOIT" == "No exploit available" ]]; then
-          if cve_searchsploit "$CVE_value" | grep -q "Exploit DB Id:" 2>/dev/null ; then
+          if cve_searchsploit "$CVE_value" 2>/dev/null| grep -q "Exploit DB Id:" 2>/dev/null ; then
             EXPLOIT="Exploit available (Source: Exploit database)"
             ((EXPLOIT_COUNTER++))
             ((EXPLOIT_COUNTER_VERSION++))

--- a/modules/P07_firmware_bin_base_analyzer.sh
+++ b/modules/P07_firmware_bin_base_analyzer.sh
@@ -18,7 +18,10 @@ P07_firmware_bin_base_analyzer() {
   module_log_init "${FUNCNAME[0]}"
   module_title "Binary firmware basic analyzer"
 
-  os_identification
+  if [[ -d "$LOG_DIR"/extractor/ ]] ; then
+    OUTPUT_DIR="$LOG_DIR"/extractor/
+    os_identification
+  fi
 
   # we only do this if we have not found a LInux filesystem
   if ! [[ -d "$FIRMWARE_PATH" ]]; then


### PR DESCRIPTION
If binwalk is not able to extract a Linux root filesystem we now try it with FACT-extractor (https://github.com/fkie-cad/fact_extractor)

![image](https://user-images.githubusercontent.com/497520/108505452-ba976e00-72b7-11eb-8957-aa42c17cf765.png)

As the installation of FACT-extractor currently fails on Kali I have used the Docker image. This means it is currently not working with -D switch.