### PR TITLE
Sudo parser updates

### DIFF
--- a/config/sudoers_files.cfg
+++ b/config/sudoers_files.cfg
@@ -1,1 +1,0 @@
-*/sudoers

--- a/modules/S115_usermode_emulator.sh
+++ b/modules/S115_usermode_emulator.sh
@@ -240,6 +240,8 @@ cleanup() {
       fi
     done
   fi
+  print_output "[*] Remove firmware copy from emulation directory.\\n\\n"
+  rm -r "$EMULATION_PATH_BASE"
 }
 
 prepare_emulator() {

--- a/modules/S50_authentication_check.sh
+++ b/modules/S50_authentication_check.sh
@@ -237,11 +237,14 @@ query_nis_plus_auth_supp() {
 check_sudoers() {
   sub_module_title "Scan and test sudoers files"
   local SUDOERS_ISSUES
+  local S_ISSUE
+  local SUDOERS_FILE_TMP
 
   for R_PATH in "${ROOT_PATH[@]}"; do
-    readarray -t SUDOERS_FILES < <(find "$R_PATH" -xdev -type f -name sudoers 2>/dev/null)
-    if [[ "${#SUDOERS_FILES[@]}" -gt 0 ]]; then
-      for SUDOERS_FILE in "${SUDOERS_FILES[@]}"; do
+    # as we only have one search term we can handle it like this:
+    readarray -t SUDOERS_FILES_ARR < <(find "$R_PATH" -xdev -type f -name sudoers 2>/dev/null)
+    if [[ "${#SUDOERS_FILES_ARR[@]}" -gt 0 ]]; then
+      for SUDOERS_FILE in "${SUDOERS_FILES_ARR[@]}"; do
         print_output "$(indent "$(orange "$(print_path "$SUDOERS_FILE")")")"
         if [[ -f "$EXT_DIR"/sudo-parser.pl ]]; then
           print_output "[*] Testing sudoers file with sudo-parse.pl:"
@@ -263,11 +266,7 @@ check_sudoers() {
 check_owner_perm_sudo_config() {
   sub_module_title "Ownership and permissions for sudo configuration files"
 
-  if [[ "$SUDOERS_FILES_COUNT" == "0" ]] ; then
-    print_output "[-] No sudoers files found - no check possible"
-  else
-    local SUDOERS_FILES_ARR
-    readarray -t SUDOERS_FILES_ARR < <(printf '%s' "$SUDOERS_FILES")
+  if [[ "${#SUDOERS_FILES_ARR[@]}" -gt 0 ]]; then
     for FILE in "${SUDOERS_FILES_ARR[@]}"; do
       local SUDOERS_D
       SUDOERS_D="$FILE"".d"
@@ -328,6 +327,8 @@ check_owner_perm_sudo_config() {
         ;;
       esac
     done
+  else
+    print_output "[-] No sudoers files found - no check possible"
   fi
 }
 

--- a/modules/S50_authentication_check.sh
+++ b/modules/S50_authentication_check.sh
@@ -248,10 +248,7 @@ check_sudoers() {
         print_output "$(indent "$(orange "$(print_path "$SUDOERS_FILE")")")"
         if [[ -f "$EXT_DIR"/sudo-parser.pl ]]; then
           print_output "[*] Testing sudoers file with sudo-parse.pl:"
-          SUDOERS_FILE_TMP="$SUDOERS_FILE"_tmp
-          sed -e "s#includedir #includedir $R_PATH#" "$SUDOERS_FILE" > "$SUDOERS_FILE_TMP"
-          readarray SUDOERS_ISSUES < <("$EXT_DIR"/sudo-parser.pl -f "$SUDOERS_FILE_TMP" | grep -E "^E:\ ")
-          rm "$SUDOERS_FILE_TMP" 2>/dev/null
+          readarray SUDOERS_ISSUES < <("$EXT_DIR"/sudo-parser.pl -f "$SUDOERS_FILE" -r "$R_PATH" | grep -E "^E:\ ")
           for S_ISSUE in "${SUDOERS_ISSUES[@]}"; do
             print_output "[+] $S_ISSUE"
           done

--- a/modules/S50_authentication_check.sh
+++ b/modules/S50_authentication_check.sh
@@ -238,7 +238,6 @@ check_sudoers() {
   sub_module_title "Scan and test sudoers files"
   local SUDOERS_ISSUES
   local S_ISSUE
-  local SUDOERS_FILE_TMP
 
   for R_PATH in "${ROOT_PATH[@]}"; do
     # as we only have one search term we can handle it like this:


### PR DESCRIPTION
thx to @timb-machine I got a better idea of how sudo-parser works internally (see also https://github.com/CiscoCXSecurity/sudo-parser/issues/8) and so I have done some updates to respect the root directory of a firmware. Now we check the found sudoers for "includedir" and fix it to our firmware root path. 

In the following example the path (etc/sudoers.d) is not included in the firmware but it tries to access the correct path:

![image](https://user-images.githubusercontent.com/497520/112473420-a3441880-8d6e-11eb-9a6b-5f4893319fcd.png)

Additionally I have included an rm in the emulation module to remove the working copy of the firmware for the s115 module
