### PR TITLE
Updated deep extraction and s110

### DIFF
--- a/emba.sh
+++ b/emba.sh
@@ -342,14 +342,18 @@ main()
   fi
 
   # Check firmware type (file/directory)
-  if [[ -d "$FIRMWARE_PATH" ]]; then
+  # copy the firmware outside of the docker and not a second time within the docker
+  if [[ -d "$FIRMWARE_PATH" ]] ; then
     PRE_CHECK=0
     print_output "[*] Firmware directory detected." "no_log"
     print_output "    Emba starts with testing the environment." "no_log"
-    print_output "    The provided firmware will be copied to ""$FIRMWARE_PATH_CP" "no_log"
-    cp -R "$FIRMWARE_PATH" "$FIRMWARE_PATH_CP""/""$(basename "$FIRMWARE_PATH")"
-    FIRMWARE_PATH="$FIRMWARE_PATH_CP""/""$(basename "$FIRMWARE_PATH")"
-    OUTPUT_DIR="$FIRMWARE_PATH_CP"
+    if [[ $IN_DOCKER -eq 0 ]] ; then
+      # in docker environment the firmware is already available
+      print_output "    The provided firmware will be copied to $ORANGE""$FIRMWARE_PATH_CP""/""$(basename "$FIRMWARE_PATH")""" "no_log"
+      cp -R "$FIRMWARE_PATH" "$FIRMWARE_PATH_CP""/""$(basename "$FIRMWARE_PATH")"
+      FIRMWARE_PATH="$FIRMWARE_PATH_CP""/""$(basename "$FIRMWARE_PATH")"
+      OUTPUT_DIR="$FIRMWARE_PATH_CP"
+    fi
   elif [[ -f "$FIRMWARE_PATH" ]]; then
     PRE_CHECK=1
     print_output "[*] Firmware binary detected." "no_log"
@@ -359,7 +363,7 @@ main()
     print_help
     exit 1
   fi
-  print_output "    Emba is running with $MAX_MODS modules in parallel." "no_log"
+  print_output "    Emba is running with $ORANGE$MAX_MODS$NC modules in parallel." "no_log"
 
   # Change log output to color for web report
   if [[ $HTML -eq 1 ]] && [[ $FORMAT_LOG -eq 0 ]]; then
@@ -381,7 +385,7 @@ main()
   #######################################################################################
   if [[ $KERNEL -eq 1 ]] && [[ $FIRMWARE -eq 0 ]] ; then
     if ! [[ -f "$KERNEL_CONFIG" ]] ; then
-      print_output "[-] Invalid kernel configuration file: $KERNEL_CONFIG" "no_log"
+      print_output "[-] Invalid kernel configuration file: $ORANGE$KERNEL_CONFIG" "no_log"
       exit 1
     else
       if ! [[ -d "$LOG_DIR" ]] ; then
@@ -427,8 +431,8 @@ main()
     if [[ $D_RETURN -eq 0 ]] ; then
       if [[ $ONLY_DEP -eq 0 ]] ; then
         print_output "[*] Emba finished analysis in docker container.\\n" "no_log"
-        print_output "[*] Firmware tested: $FIRMWARE_PATH" "no_log"
-        print_output "[*] Log directory: $LOG_DIR" "no_log"
+        print_output "[*] Firmware tested: $ORANGE$FIRMWARE_PATH" "no_log"
+        print_output "[*] Log directory: $ORANGE$LOG_DIR" "no_log"
         exit
       fi
     else
@@ -505,7 +509,7 @@ main()
       write_grep_log "$(date)" "TIMESTAMP"
 
       if [[ "${#ROOT_PATH[@]}" -eq 0 ]]; then
-        detect_root_dir_helper "$FIRMWARE_PATH"
+        detect_root_dir_helper "$FIRMWARE_PATH" "main"
       fi
 
       check_firmware

--- a/helpers/helpers.sh
+++ b/helpers/helpers.sh
@@ -68,9 +68,15 @@ wait_for_pid() {
 }
 
 max_pids_protection() {
+  if [[ -n "$1" ]]; then
+    local MAX_PIDS_="$1"
+    shift
+  else
+    local MAX_PIDS_="$MAX_MODS"
+  fi
   local WAIT_PIDS=("$@")
   local PID
-  while [[ ${#WAIT_PIDS[@]} -gt "$MAX_PIDS" ]]; do
+  while [[ ${#WAIT_PIDS[@]} -gt "$MAX_PIDS_" ]]; do
     TEMP_PIDS=()
     # check for really running PIDs and re-create the array
     for PID in ${WAIT_PIDS[*]}; do
@@ -79,11 +85,39 @@ max_pids_protection() {
         TEMP_PIDS+=( "$PID" )
       fi
     done
+    #print_output "[!] really running pids: ${#TEMP_PIDS[@]}"
 
     # recreate the arry with the current running PIDS
     WAIT_PIDS=()
     WAIT_PIDS=("${TEMP_PIDS[@]}")
     echo "." | tr -d "\n"
   done
+}
+
+cleaner() {
+  print_output "[*] Ctrl+C detected!" "no_log"
+  print_output "[*] Final cleanup started." "no_log"
+  # now we can unmount the stuff from emulator and delete temporary stuff
+
+  # if S115 is found only once in main.log the module was started and we have to clean it up
+  if [[ $(grep -c S115 "$LOG_DIR"/"$MAIN_LOG_FILE") -eq 1 ]]; then
+    print_output "[*] Terminating qemu processes - check it with ps" "no_log"
+    killall -9 --quiet -r .*qemu.*sta.*
+    print_output "[*] Cleaning the emulation environment\\n" "no_log"
+    find "$FIRMWARE_PATH_CP" -xdev -iname "qemu*static" -exec rm {} \; 2>/dev/null
+    print_output "[*] Umounting proc, sys and run" "no_log"
+    mapfile -t CHECK_MOUNTS < <(mount | grep "$FIRMWARE_PATH_CP")
+    for MOUNT in "${CHECK_MOUNTS[@]}"; do
+      print_output "[*] Unmounting $MOUNT" "no_log"
+      MOUNT=$(echo "$MOUNT" | cut -d\  -f3)
+      umount -l "$MOUNT"
+    done
+  fi
+
+  if [[ -d "$TMP_DIR" ]]; then
+    rm -r "$TMP_DIR" 2>/dev/null
+  fi
+  print_output "[!] Test ended on ""$(date)"" and took about ""$(date -d@$SECONDS -u +%H:%M:%S)"" \\n" "no_log"
+  exit 1
 }
 

--- a/helpers/helpers.sh
+++ b/helpers/helpers.sh
@@ -100,18 +100,20 @@ cleaner() {
   # now we can unmount the stuff from emulator and delete temporary stuff
 
   # if S115 is found only once in main.log the module was started and we have to clean it up
-  if [[ $(grep -c S115 "$LOG_DIR"/"$MAIN_LOG_FILE") -eq 1 ]]; then
-    print_output "[*] Terminating qemu processes - check it with ps" "no_log"
-    killall -9 --quiet -r .*qemu.*sta.*
-    print_output "[*] Cleaning the emulation environment\\n" "no_log"
-    find "$FIRMWARE_PATH_CP" -xdev -iname "qemu*static" -exec rm {} \; 2>/dev/null
-    print_output "[*] Umounting proc, sys and run" "no_log"
-    mapfile -t CHECK_MOUNTS < <(mount | grep "$FIRMWARE_PATH_CP")
-    for MOUNT in "${CHECK_MOUNTS[@]}"; do
-      print_output "[*] Unmounting $MOUNT" "no_log"
-      MOUNT=$(echo "$MOUNT" | cut -d\  -f3)
-      umount -l "$MOUNT"
-    done
+  if [[ -f "$LOG_DIR"/"$MAIN_LOG_FILE" ]]; then
+    if [[ $(grep -c S115 "$LOG_DIR"/"$MAIN_LOG_FILE") -eq 1 ]]; then
+      print_output "[*] Terminating qemu processes - check it with ps" "no_log"
+      killall -9 --quiet -r .*qemu.*sta.*
+      print_output "[*] Cleaning the emulation environment\\n" "no_log"
+      find "$FIRMWARE_PATH_CP" -xdev -iname "qemu*static" -exec rm {} \; 2>/dev/null
+      print_output "[*] Umounting proc, sys and run" "no_log"
+      mapfile -t CHECK_MOUNTS < <(mount | grep "$FIRMWARE_PATH_CP")
+      for MOUNT in "${CHECK_MOUNTS[@]}"; do
+        print_output "[*] Unmounting $MOUNT" "no_log"
+        MOUNT=$(echo "$MOUNT" | cut -d\  -f3)
+        umount -l "$MOUNT"
+      done
+    fi
   fi
 
   if [[ -d "$TMP_DIR" ]]; then

--- a/helpers/prepare.sh
+++ b/helpers/prepare.sh
@@ -243,7 +243,12 @@ check_firmware()
 
 detect_root_dir_helper() {
   SEARCH_PATH="$1"
-  print_output "[*] Root directory auto detection (could take some time)\\n" "no_log"
+  if [[ -n "$2" ]];then
+    LOGGER="$2"
+  else
+    LOGGER="no_log"
+  fi
+  print_output "[*] Root directory auto detection (could take some time)\\n" "$LOGGER"
   ROOT_PATH=()
   export ROOT_PATH
   local R_PATH
@@ -268,16 +273,16 @@ detect_root_dir_helper() {
   fi
 
   if [[ ${#ROOT_PATH[@]} -eq 0 ]]; then
-    print_output "[*] Root directory set to firmware path ... last resort" "no_log"
+    print_output "[*] Root directory set to firmware path ... last resort" "$LOGGER"
     ROOT_PATH+=( "$SEARCH_PATH" )
   fi
 
   eval "ROOT_PATH=($(for i in "${ROOT_PATH[@]}" ; do echo "\"$i\"" ; done | sort -u))"
   if [[ ${#ROOT_PATH[@]} -gt 1 ]]; then
-    print_output "[*] Found $ORANGE${#ROOT_PATH[@]}$NC different root directories:" "no_log"
+    print_output "[*] Found $ORANGE${#ROOT_PATH[@]}$NC different root directories:" "$LOGGER"
   fi
   for R_PATH in "${ROOT_PATH[@]}"; do
-    print_output "[+] Found the following root directory: $R_PATH" "no_log"
+    print_output "[+] Found the following root directory: $R_PATH" "$LOGGER"
   done
 }
 

--- a/helpers/prepare.sh
+++ b/helpers/prepare.sh
@@ -115,6 +115,7 @@ architecture_check()
         ARCH_PPC=$((ARCH_PPC+1))
       fi
     done
+
     if [[ $((ARCH_MIPS+ARCH_ARM+ARCH_X64+ARCH_X86+ARCH_PPC)) -gt 0 ]] ; then
       print_output "$(indent "$(orange "Architecture  Count")")" "no_log"
       if [[ $ARCH_MIPS -gt 0 ]] ; then print_output "$(indent "$(orange "MIPS          ""$ARCH_MIPS")")" "no_log" ; fi

--- a/helpers/print.sh
+++ b/helpers/print.sh
@@ -396,21 +396,21 @@ print_help()
 print_firmware_info()
 {
   if [[ -n "$1" || -n "$2" || -n "$3" || -n "$4" ]]; then
-    print_output "\\n-----------------------------------------------------------------\\n" "no_log"
+    print_bar "no_log"
     print_output "[*] Firmware information:" "no_log"
     if [[ -n "$1" ]]; then
-      print_output "$(indent "$BOLD""Vendor: ""$NC""$ORANGE""$1""$NC")" "no_log"
+      print_output "$(indent "$BOLD""Vendor:\t""$NC""$ORANGE""$1""$NC")" "no_log"
     fi
     if [[ -n "$2" ]]; then
-      print_output "$(indent "$BOLD""Version: ""$NC""$ORANGE""$2""$NC")" "no_log"
+      print_output "$(indent "$BOLD""Version:\t""$NC""$ORANGE""$2""$NC")" "no_log"
     fi
     if [[ -n "$3" ]]; then
-      print_output "$(indent "$BOLD""Device: ""$NC""$ORANGE""$3""$NC")" "no_log"
+      print_output "$(indent "$BOLD""Device:\t""$NC""$ORANGE""$3""$NC")" "no_log"
     fi
     if [[ -n "$4" ]]; then
-      print_output "$(indent "$BOLD""Additional notes: ""$NC""$ORANGE""$4""$NC")" "no_log"
+      print_output "$(indent "$BOLD""Additional notes:\t""$NC""$ORANGE""$4""$NC")" "no_log"
     fi
-    print_output "\\n-----------------------------------------------------------------\\n" "no_log"
+    print_bar "no_log"
   fi
 }
 
@@ -440,7 +440,11 @@ print_excluded()
   fi
 }
 print_bar() {
-  print_output "\\n-----------------------------------------------------------------\\n"
+  if [[ -n "$1" ]]; then
+    print_output "\\n-----------------------------------------------------------------\\n" "$1"
+  else
+    print_output "\\n-----------------------------------------------------------------\\n"
+  fi
 }
 
 module_start_log() {
@@ -458,11 +462,6 @@ module_end_log() {
 
   if [[ "$MODULE_REPORT_STATE" -eq 0 ]]; then
     print_output "[-] $(date) - $MODULE_MAIN_NAME nothing reported"
-  fi
-
-  if [[ "$MODULE_MAIN_NAME" == "S09_firmware_base_version_check" ]]; then
-    print_output "[*] $MODULE_MAIN_NAME finished - increase number of maximum running modules"
-    export MAX_MODS=15
   fi
 
   run_web_reporter_mod_name "$MODULE_MAIN_NAME"

--- a/helpers/print.sh
+++ b/helpers/print.sh
@@ -462,7 +462,7 @@ module_end_log() {
 
   if [[ "$MODULE_MAIN_NAME" == "S09_firmware_base_version_check" ]]; then
     print_output "[*] $MODULE_MAIN_NAME finished - increase number of maximum running modules"
-    export MAX_PIDS=15
+    export MAX_MODS=15
   fi
 
   run_web_reporter_mod_name "$MODULE_MAIN_NAME"

--- a/modules/F19_cve_aggregator.sh
+++ b/modules/F19_cve_aggregator.sh
@@ -691,14 +691,13 @@ generate_cve_details() {
 
   CVE_COUNTER=0
   EXPLOIT_COUNTER=0
-  export MAX_PIDS=20 # for accessing the mongodb in threaded mode
 
   for VERSION in "${VERSIONS_CLEANED[@]}"; do
     # threading currently not working. This is work in progress
     if [[ "$THREADED" -eq 1 ]]; then
       cve_db_lookup &
       WAIT_PIDS_F19+=( "$!" )
-      max_pids_protection "${WAIT_PIDS_F19[@]}"
+      max_pids_protection 10 "${WAIT_PIDS_F19[@]}"
     else
       cve_db_lookup
     fi

--- a/modules/F50_base_aggregator.sh
+++ b/modules/F50_base_aggregator.sh
@@ -279,6 +279,10 @@ get_data() {
     FILE_ARR_COUNT=$(grep -a "\[\*\]\ Statistics:" "$LOG_DIR"/"$S05_LOG" | cut -d: -f2)
     DETECTED_DIR=$(grep -a "\[\*\]\ Statistics:" "$LOG_DIR"/"$S05_LOG" | cut -d: -f3)
   fi
+  if ! [[ "$FILE_ARR_COUNT" -gt 0 ]]; then
+    FILE_ARR_COUNT=$(find "$FIRMWARE_PATH_CP" -type f | wc -l)
+    DETECTED_DIR=$(find "$FIRMWARE_PATH_CP" -type d | wc -l)
+  fi
   if [[ -f "$LOG_DIR"/"$S10_LOG" ]]; then
     STRCPY_CNT=$(grep -a "\[\*\]\ Statistics:" "$LOG_DIR"/"$S10_LOG" | cut -d: -f2)
     ARCH=$(grep -a "\[\*\]\ Statistics1:" "$LOG_DIR"/"$S10_LOG" | cut -d: -f2)

--- a/modules/P05_firmware_bin_extractor.sh
+++ b/modules/P05_firmware_bin_extractor.sh
@@ -29,6 +29,7 @@ P05_firmware_bin_extractor() {
   # shellcheck disable=SC2153
   if [[ $FACT_EXTRACTOR -eq 1 && $LINUX_PATH_COUNTER -lt 2 ]]; then
     fact_extractor
+    linux_basic_identification_helper
   fi
 
   FILES_BINWALK=$(find "$OUTPUT_DIR_binwalk" -xdev -type f | wc -l )
@@ -43,15 +44,13 @@ P05_firmware_bin_extractor() {
     print_output "[*] Default FACT-extractor extracted $ORANGE$FILES_FACT$NC files."
   fi
 
-  linux_basic_identification_helper
-
   # If we have not found a linux filesystem we try to do a binwalk -e -M on every file for two times
   # Manual activation via -x switch:
   if [[ $LINUX_PATH_COUNTER -lt 2 || $DEEP_EXTRACTOR -eq 1 ]] ; then
     deep_extractor
   fi
 
-  detect_root_dir_helper "$FIRMWARE_PATH_CP"
+  detect_root_dir_helper "$FIRMWARE_PATH_CP" "$(get_log_file)"
 
   FILES_EXT=$(find "$FIRMWARE_PATH_CP" -xdev -type f | wc -l )
 
@@ -322,5 +321,5 @@ extract_deb_extractor_helper(){
   dpkg-deb --extract "$DEB" "$R_PATH"
 }
 linux_basic_identification_helper() {
-  LINUX_PATH_COUNTER="$(find "$OUTPUT_DIR_binwalk" "${EXCL_FIND[@]}" -xdev -type d -iname bin -o -type f -iname busybox -o -type d -iname sbin -o -type d -iname etc 2> /dev/null | wc -l)"
+  LINUX_PATH_COUNTER="$(find "$FIRMWARE_PATH_CP" "${EXCL_FIND[@]}" -xdev -type d -iname bin -o -type f -iname busybox -o -type d -iname sbin -o -type d -iname etc 2> /dev/null | wc -l)"
 }

--- a/modules/P05_firmware_bin_extractor.sh
+++ b/modules/P05_firmware_bin_extractor.sh
@@ -23,7 +23,7 @@ P05_firmware_bin_extractor() {
   # we love binwalk ... this is our first chance for extracting everything
   binwalking
 
-  LINUX_PATH_COUNTER="$(find "$OUTPUT_DIR_binwalk" "${EXCL_FIND[@]}" -xdev -type d -iname bin -o -type f -iname busybox -o -type d -iname sbin -o -type d -iname etc 2> /dev/null | wc -l)"
+  linux_basic_identification_helper
 
   # if we have not found a linux filesystem we try to extract the firmware again with FACT-extractor
   # shellcheck disable=SC2153
@@ -43,8 +43,11 @@ P05_firmware_bin_extractor() {
     print_output "[*] Default FACT-extractor extracted $ORANGE$FILES_FACT$NC files."
   fi
 
-  # if we have not found a linux filesystem we try to do a binwalk -e -M on every file
-  if [[ $DEEP_EXTRACTOR -eq 1 ]] ; then
+  linux_basic_identification_helper
+
+  # If we have not found a linux filesystem we try to do a binwalk -e -M on every file for two times
+  # Manual activation via -x switch:
+  if [[ $LINUX_PATH_COUNTER -lt 2 || $DEEP_EXTRACTOR -eq 1 ]] ; then
     deep_extractor
   fi
 
@@ -74,7 +77,7 @@ wait_for_extractor() {
   OUTPUT_DIR="$FIRMWARE_PATH_CP"
   SEARCHER=$(basename "$FIRMWARE_PATH")
 
-  # this is not solid and we have to probably adjust it in the future
+  # this is not solid and we probably have to adjust it in the future
   # but for now it works
   SEARCHER="$(echo "$SEARCHER" | tr "(" "." | tr ")" ".")"
 
@@ -116,13 +119,19 @@ ipk_extractor() {
       mkdir "$LOG_DIR"/ipk_tmp
       for R_PATH in "${ROOT_PATH[@]}"; do
         while read -r IPK; do
-          IPK_NAME=$(basename "$IPK")
-          print_output "[*] Extracting $ORANGE$IPK_NAME$NC package to the root directory $ORANGE$R_PATH$NC."
-          tar zxpf "$IPK" --directory "$LOG_DIR"/ipk_tmp
-          tar xzf "$LOG_DIR"/ipk_tmp/data.tar.gz --directory "$R_PATH"
-          rm -r "$LOG_DIR"/ipk_tmp/*
+          if [[ "$THREADED" -eq 1 ]]; then
+            extract_ipk_extractor_helper &
+            WAIT_PIDS_P05+=( "$!" )
+          else
+            extract_ipk_extractor_helper
+          fi
         done < "$TMP_DIR"/ipk_db.txt
       done
+
+      if [[ "$THREADED" -eq 1 ]]; then
+        wait_for_pid "${WAIT_PIDS_P05[@]}"
+      fi
+
       FILES_AFTER_IPK=$(find "$FIRMWARE_PATH_CP" -xdev -type f | wc -l )
       echo ""
       print_output "[*] Before ipk extraction we had $ORANGE$FILES_EXT$NC files, after deep extraction we have $ORANGE$FILES_AFTER_IPK$NC files extracted."
@@ -145,11 +154,19 @@ deb_extractor() {
       print_output "[*] Found $ORANGE$DEB_ARCHIVES$NC debian archives - extracting them to the root directories ..."
       for R_PATH in "${ROOT_PATH[@]}"; do
         while read -r DEB; do
-          DEB_NAME=$(basename "$DEB")
-          print_output "[*] Extracting $ORANGE$DEB_NAME$NC package to the root directory $ORANGE$R_PATH$NC."
-          dpkg-deb --extract "$DEB" "$R_PATH"
+          if [[ "$THREADED" -eq 1 ]]; then
+            extract_deb_extractor_helper &
+            WAIT_PIDS_P05+=( "$!" )
+          else
+            extract_deb_extractor_helper
+          fi
         done < "$TMP_DIR"/deb_db.txt
       done
+
+      if [[ "$THREADED" -eq 1 ]]; then
+        wait_for_pid "${WAIT_PIDS_P05[@]}"
+      fi
+
       FILES_AFTER_DEB=$(find "$FIRMWARE_PATH_CP" -xdev -type f | wc -l )
       echo ""
       print_output "[*] Before deb extraction we had $ORANGE$FILES_EXT$NC files, after deep extraction we have $ORANGE$FILES_AFTER_DEB$NC files extracted."
@@ -158,14 +175,54 @@ deb_extractor() {
 }
 
 deep_extractor() {
-  sub_module_title "Walking through all files and try to extract what ever possible"
+  sub_module_title "Deep extraction mode"
   print_output "[*] Deep extraction with binwalk - 1st round"
+  print_output "[*] Walking through all files and try to extract what ever possible"
+
+  local FILE_ARR_TMP
+  local FILE_MD5
+  local MD5_DONE_DEEP
 
   FILES_BEFORE_DEEP=$(find "$FIRMWARE_PATH_CP" -xdev -type f | wc -l )
-  find "$FIRMWARE_PATH_CP" -xdev -type f ! -name "*.deb" ! -name "*.ipk" -exec binwalk -e -M -C "$FIRMWARE_PATH_CP" {} \;
+  readarray -t FILE_ARR_TMP < <(find "$FIRMWARE_PATH_CP" -xdev "${EXCL_FIND[@]}" -type f ! \( -name "*.udeb" -o -name "*.deb" -o -name "*.ipk" \) -exec md5sum {} \; 2>/dev/null | sort -u -k1,1 | cut -d\  -f3 )
+  for FILE_TMP in "${FILE_ARR_TMP[@]}"; do
+    if [[ "$THREADED" -eq 1 ]]; then
+      binwalk_deep_extract_helper &
+      WAIT_PIDS_P05+=( "$!" )
+    else
+      binwalk_deep_extract_helper
+    fi
+    #let's build an array with all our unique md5 checksums of our files
+    FILE_MD5=$(md5sum "$FILE_TMP" | cut -d\  -f1)
+    MD5_DONE_DEEP+=( "$FILE_MD5" )
+  done
+
+  if [[ "$THREADED" -eq 1 ]]; then
+    wait_for_pid "${WAIT_PIDS_P05[@]}"
+  fi
 
   print_output "[*] Deep extraction with binwalk - 2nd round"
-  find "$FIRMWARE_PATH_CP" -xdev -type f ! -name "*.deb" ! -name "*.ipk" -exec binwalk -e -M -C "$FIRMWARE_PATH_CP" {} \;
+  print_output "[*] Walking through all files and try to extract what ever possible"
+
+  readarray -t FILE_ARR_TMP < <(find "$FIRMWARE_PATH_CP" -xdev "${EXCL_FIND[@]}" -type f ! \( -name "*.udeb" -o -name "*.deb" -o -name "*.ipk" \) -exec md5sum {} \; 2>/dev/null | sort -u -k1,1 | cut -d\  -f3 )
+  for FILE_TMP in "${FILE_ARR_TMP[@]}"; do
+    FILE_MD5=$(md5sum "$FILE_TMP" | cut -d\  -f1)
+    # let's check the current md5sum against our array of unique md5sums - if we have a match this is already extracted
+    # already extracted stuff is now ignored
+    if [[ ! " ${MD5_DONE_DEEP[*]} " =~ ${FILE_MD5} ]]; then
+      if [[ "$THREADED" -eq 1 ]]; then
+        binwalk_deep_extract_helper &
+        WAIT_PIDS_P05+=( "$!" )
+      else
+        binwalk_deep_extract_helper
+      fi
+      MD5_DONE_DEEP+=( "$FILE_MD5" )
+    fi
+  done
+
+  if [[ "$THREADED" -eq 1 ]]; then
+    wait_for_pid "${WAIT_PIDS_P05[@]}"
+  fi
 
   FILES_AFTER_DEEP=$(find "$FIRMWARE_PATH_CP" -xdev -type f | wc -l )
 
@@ -258,5 +315,23 @@ extract_ipk_helper() {
   find "$FIRMWARE_PATH_CP" -xdev -type f -name "*.ipk" -exec md5sum {} \; 2>/dev/null | sort -u -k1,1 | cut -d\  -f3 >> "$TMP_DIR"/ipk_db.txt
 }
 extract_deb_helper() {
-  find "$FIRMWARE_PATH_CP" -xdev -type f -name "*.deb" -exec md5sum {} \; 2>/dev/null | sort -u -k1,1 | cut -d\  -f3 >> "$TMP_DIR"/deb_db.txt
+  find "$FIRMWARE_PATH_CP" -xdev -type f \( -name "*.deb" -o -name "*.udeb" \) -exec md5sum {} \; 2>/dev/null | sort -u -k1,1 | cut -d\  -f3 >> "$TMP_DIR"/deb_db.txt
+}
+binwalk_deep_extract_helper() {
+  binwalk -e -M -C "$FIRMWARE_PATH_CP" "$FILE_TMP"
+}
+extract_deb_extractor_helper(){
+  DEB_NAME=$(basename "$DEB")
+  print_output "[*] Extracting $ORANGE$DEB_NAME$NC package to the root directory $ORANGE$R_PATH$NC."
+  dpkg-deb --extract "$DEB" "$R_PATH"
+}
+extract_ipk_extractor_helper(){
+  IPK_NAME=$(basename "$IPK")
+  print_output "[*] Extracting $ORANGE$IPK_NAME$NC package to the root directory $ORANGE$R_PATH$NC."
+  tar zxpf "$IPK" --directory "$LOG_DIR"/ipk_tmp
+  tar xzf "$LOG_DIR"/ipk_tmp/data.tar.gz --directory "$R_PATH"
+  rm -r "$LOG_DIR"/ipk_tmp/*
+}
+linux_basic_identification_helper() {
+  LINUX_PATH_COUNTER="$(find "$OUTPUT_DIR_binwalk" "${EXCL_FIND[@]}" -xdev -type d -iname bin -o -type f -iname busybox -o -type d -iname sbin -o -type d -iname etc 2> /dev/null | wc -l)"
 }

--- a/modules/P05_firmware_bin_extractor.sh
+++ b/modules/P05_firmware_bin_extractor.sh
@@ -119,22 +119,18 @@ ipk_extractor() {
       mkdir "$LOG_DIR"/ipk_tmp
       for R_PATH in "${ROOT_PATH[@]}"; do
         while read -r IPK; do
-          if [[ "$THREADED" -eq 1 ]]; then
-            extract_ipk_extractor_helper &
-            WAIT_PIDS_P05+=( "$!" )
-          else
-            extract_ipk_extractor_helper
-          fi
+          IPK_NAME=$(basename "$IPK")
+          print_output "[*] Extracting $ORANGE$IPK_NAME$NC package to the root directory $ORANGE$R_PATH$NC."
+          tar zxpf "$IPK" --directory "$LOG_DIR"/ipk_tmp
+          tar xzf "$LOG_DIR"/ipk_tmp/data.tar.gz --directory "$R_PATH"
+          rm -r "$LOG_DIR"/ipk_tmp/*
         done < "$TMP_DIR"/ipk_db.txt
       done
-
-      if [[ "$THREADED" -eq 1 ]]; then
-        wait_for_pid "${WAIT_PIDS_P05[@]}"
-      fi
 
       FILES_AFTER_IPK=$(find "$FIRMWARE_PATH_CP" -xdev -type f | wc -l )
       echo ""
       print_output "[*] Before ipk extraction we had $ORANGE$FILES_EXT$NC files, after deep extraction we have $ORANGE$FILES_AFTER_IPK$NC files extracted."
+      rm -r "$LOG_DIR"/ipk_tmp
     fi
   fi
 }
@@ -324,13 +320,6 @@ extract_deb_extractor_helper(){
   DEB_NAME=$(basename "$DEB")
   print_output "[*] Extracting $ORANGE$DEB_NAME$NC package to the root directory $ORANGE$R_PATH$NC."
   dpkg-deb --extract "$DEB" "$R_PATH"
-}
-extract_ipk_extractor_helper(){
-  IPK_NAME=$(basename "$IPK")
-  print_output "[*] Extracting $ORANGE$IPK_NAME$NC package to the root directory $ORANGE$R_PATH$NC."
-  tar zxpf "$IPK" --directory "$LOG_DIR"/ipk_tmp
-  tar xzf "$LOG_DIR"/ipk_tmp/data.tar.gz --directory "$R_PATH"
-  rm -r "$LOG_DIR"/ipk_tmp/*
 }
 linux_basic_identification_helper() {
   LINUX_PATH_COUNTER="$(find "$OUTPUT_DIR_binwalk" "${EXCL_FIND[@]}" -xdev -type d -iname bin -o -type f -iname busybox -o -type d -iname sbin -o -type d -iname etc 2> /dev/null | wc -l)"

--- a/modules/P05_firmware_bin_extractor.sh
+++ b/modules/P05_firmware_bin_extractor.sh
@@ -103,7 +103,7 @@ wait_for_extractor() {
 }
 
 ipk_extractor() {
-  print_output ""
+  sub_module_title "IPK archive extraction mode"
   print_output "[*] Identify ipk archives and extracting it to the root directories ..."
   extract_ipk_helper &
   # this does not work as expected -> we have to check it again
@@ -135,7 +135,7 @@ ipk_extractor() {
 }
 
 deb_extractor() {
-  print_output ""
+  sub_module_title "Debian archive extraction mode"
   print_output "[*] Identify debian archives and extracting it to the root directories ..."
   extract_deb_helper &
   # this does not work as expected -> we have to check it again
@@ -313,7 +313,7 @@ extract_deb_helper() {
   find "$FIRMWARE_PATH_CP" -xdev -type f \( -name "*.deb" -o -name "*.udeb" \) -exec md5sum {} \; 2>/dev/null | sort -u -k1,1 | cut -d\  -f3 >> "$TMP_DIR"/deb_db.txt
 }
 binwalk_deep_extract_helper() {
-  binwalk -e -M -C "$FIRMWARE_PATH_CP" "$FILE_TMP"
+  binwalk -e -M -C "$FIRMWARE_PATH_CP" "$FILE_TMP" | tee -a "$LOG_DIR"/p05_binwalker_deep.txt
 }
 extract_deb_extractor_helper(){
   DEB_NAME=$(basename "$DEB")

--- a/modules/S09_firmware_base_version_check.sh
+++ b/modules/S09_firmware_base_version_check.sh
@@ -30,9 +30,11 @@ S09_firmware_base_version_check() {
   module_title "Binary firmware versions detection"
 
   EXTRACTOR_LOG="$LOG_DIR"/p05_firmware_bin_extractor.txt
-  # a first try to not kill the system with too many version detection tasks
-  MAX_THREADS_S09=$((7*"$(grep -c ^processor /proc/cpuinfo)"))
-  print_output "[*] Max threads for static version detection: $MAX_THREADS_S09"
+  if [[ "$THREADED" -eq 1 ]]; then
+    # a first try to not kill the system with too many version detection tasks
+    MAX_THREADS_S09=$((7*"$(grep -c ^processor /proc/cpuinfo)"))
+    print_output "[*] Max threads for static version detection: $MAX_THREADS_S09"
+  fi
 
   print_output "[*] Static version detection running ..." | tr -d "\n"
   while read -r VERSION_LINE; do

--- a/modules/S110_yara_check.sh
+++ b/modules/S110_yara_check.sh
@@ -62,17 +62,18 @@ S110_yara_check()
     print_output "[!] Check with yara not possible, because it isn't installed!"
   fi
 
-
   module_end_log "${FUNCNAME[0]}" "$YARA_CNT"
 }
 
 yara_check() {
   if [[ -e "$YARA_S_FILE" ]] ; then
     local S_OUTPUT
-    S_OUTPUT="$(yara -r -w ./dir-combined.yara "$YARA_S_FILE")"
-    if [[ -n "$S_OUTPUT" ]] ; then
-      print_output "[+] ""$(echo -e "$S_OUTPUT" | head -n1 | cut -d " " -f1)"" ""$(white "$(print_path "$YARA_S_FILE")")"
-      echo "1" >> "$TMP_DIR"/YARA_CNT.tmp
+    mapfile -t S_OUTPUT < <(yara -r -w ./dir-combined.yara "$YARA_S_FILE")
+    if [[ "${#S_OUTPUT[@]}" -gt 0 ]] ; then
+      for YARA_OUT in "${S_OUTPUT[@]}"; do
+        print_output "[+] ""$(echo -e "$YARA_OUT" | cut -d " " -f1)"" ""$(white "$(print_path "$YARA_S_FILE")")"
+        echo "1" >> "$TMP_DIR"/YARA_CNT.tmp
+      done
     fi
   fi
 }

--- a/modules/S115_usermode_emulator.sh
+++ b/modules/S115_usermode_emulator.sh
@@ -47,7 +47,7 @@ S115_usermode_emulator() {
 
     # we only need to detect the root directory again if we have copied it before
     if [[ -d "$FIRMWARE_PATH_BAK" ]]; then
-      detect_root_dir_helper "$EMULATION_PATH_BASE"
+      detect_root_dir_helper "$EMULATION_PATH_BASE" "$(get_log_file)"
     fi
 
     print_output "[*] Detected ${#ROOT_PATH[@]} root directories:"


### PR DESCRIPTION
Started with some little updates in different areas. Currently the following changes are included:

* deep extraction rework - we can enforce it with -x as already known. It emba does not detect a root filesystem in normal mode after the initial extraction then the deep extraction mode is activated automatically
* deep extraction is now threaded
* S110 memory exhaustion bug fixed
* "cleaner function" updated to clean up the mess of s115 if we kill emba with ctrl+c
* maximum number of running modules is now automatically adjusted (per core one module - at least two modules)
* maximum number of running s09 detection processes is now automatically adjusted (probably we have to adjust this a bit more)
* do not copy the firmware directory twice in docker mode
* 