### PR TITLE
Installer, csv, remove firmware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM kalilinux/kali-rolling
 
 RUN apt-get update && \ 
     apt-get -y upgrade && \
-    apt-get -y install wget kmod procps sudo apt-utils
+    apt-get -y install wget kmod procps sudo dialog apt-utils
 
 ADD ./installer.sh /
 

--- a/emba.sh
+++ b/emba.sh
@@ -669,7 +669,7 @@ main()
     update_index
   fi
   if [[ -f "$HTML_PATH"/index.html ]]; then
-    print_output "[*] Web report created HTML report in $LOG_DIR/html-report\\n" "main" 
+    print_output "[*] Web report created HTML report in $ORANGE$LOG_DIR/html-report$NC\\n" "main" 
   fi
 }
 

--- a/helpers/print.sh
+++ b/helpers/print.sh
@@ -431,6 +431,7 @@ print_help()
   echo -e "$CYAN""-x""$NC""                Enable deep extraction - try to extract every file two times with binwalk (WARNING: Uses a lot of disk space)"
   echo -e "$CYAN""-t""$NC""                Activate multi threading (destroys regular console output)"
   echo -e "$CYAN""-o""$NC""                Activate online checks (e.g. upload and test with VirusTotal)"
+  echo -e "$CYAN""-r""$NC""                Remove temprorary firmware directory after testing"
   echo -e "\\nModify output"
   echo -e "$CYAN""-s""$NC""                Prints only relative paths"
   echo -e "$CYAN""-z""$NC""                Adds ANSI color codes to log"

--- a/installer.sh
+++ b/installer.sh
@@ -580,7 +580,7 @@ case ${ANSWER:0:1} in
       fi
       case ${ANSWER:0:1} in
         y|Y )
-          #cve_searchsploit -u
+          cve_searchsploit -u
         ;;
       esac    
     fi
@@ -597,7 +597,10 @@ print_tool_info "python3-pyqt5" 1
 print_tool_info "python3-pyqt5.qtopengl" 1
 print_tool_info "python3-numpy" 1
 print_tool_info "python3-scipy" 1
+# python2 is needed for ubireader installation
 print_tool_info "python2" 1
+# python-setuptools is needed for ubireader installation
+print_tool_info "python-setuptools" 1
 print_tool_info "mtd-utils" 1
 print_tool_info "gzip" 1
 print_tool_info "bzip2" 1
@@ -697,12 +700,13 @@ case ${ANSWER:0:1} in
       cd ./external/binwalk/ubi_reader || exit 1
       git reset --hard 0955e6b95f07d849a182125919a1f2b6790d5b51
       python2 setup.py install
-      cd .. || exit 1
+      cd ../../.. || exit 1
     else
       echo -e "$GREEN""ubi_reader already installed""$NC"
     fi
 
     if ! command -v binwalk > /dev/null ; then
+      cd ./external/binwalk
       python3 setup.py install
     else
       echo -e "$GREEN""binwalk already installed""$NC"

--- a/installer.sh
+++ b/installer.sh
@@ -616,6 +616,7 @@ print_tool_info "build-essential" 1
 print_tool_info "zlib1g-dev" 1
 print_tool_info "liblzma-dev" 1
 print_tool_info "liblzo2-dev" 1
+# firmware-mod-kit is only available on Kali Linux
 print_tool_info "firmware-mod-kit" 1
 
 if [[ "$FORCE" -eq 0 ]] && [[ "$LIST_DEP" -eq 0 ]] ; then
@@ -629,88 +630,89 @@ else
 fi
 case ${ANSWER:0:1} in
   y|Y )
+    BINWALK_PRE_AVAILABLE=0
 
-      apt-get install "${INSTALL_APP_LIST[@]}" -y
+    apt-get install "${INSTALL_APP_LIST[@]}" -y
 
-      pip3 install nose
-      pip3 install coverage
-      pip3 install pyqtgraph
-      pip3 install capstone
-      pip3 install cstruct
+    pip3 install nose
+    pip3 install coverage
+    pip3 install pyqtgraph
+    pip3 install capstone
+    pip3 install cstruct
 
-      git clone https://github.com/ReFirmLabs/binwalk.git external/binwalk
+    git clone https://github.com/ReFirmLabs/binwalk.git external/binwalk
 
-      if ! command -v yaffshiv1 > /dev/null ; then
-        git clone https://github.com/devttys0/yaffshiv external/binwalk/yaffshiv
-        python3 ./external/binwalk/yaffshiv/setup.py install
-      else
-        echo -e "$GREEN""yaffshiv already installed""$NC"
-      fi
+    if ! command -v yaffshiv > /dev/null ; then
+      git clone https://github.com/devttys0/yaffshiv external/binwalk/yaffshiv
+      cd ./external/binwalk/yaffshiv/
+      python3 setup.py install
+      cd ../../.. || exit 1
+    else
+      echo -e "$GREEN""yaffshiv already installed""$NC"
+    fi
 
-      if ! command -v sasquatch > /dev/null ; then
-        git clone https://github.com/devttys0/sasquatch external/binwalk/sasquatch
-        CFLAGS=-fcommon ./external/binwalk/sasquatch/build.sh -y
-      else
-        echo -e "$GREEN""sasquatch already installed""$NC"
-      fi
+    if ! command -v sasquatch > /dev/null ; then
+      git clone https://github.com/devttys0/sasquatch external/binwalk/sasquatch
+      CFLAGS=-fcommon ./external/binwalk/sasquatch/build.sh -y
+    else
+      echo -e "$GREEN""sasquatch already installed""$NC"
+    fi
 
-      if ! command -v jefferson > /dev/null ; then
-        git clone https://github.com/sviehb/jefferson external/binwalk/jefferson
-        pip3 install -r ./external/binwalk/jefferson/requirements.txt
-        python3 ./external/binwalk/jefferson/setup.py install
-      else
-        echo -e "$GREEN""jefferson already installed""$NC"
-      fi
+    if ! command -v jefferson > /dev/null ; then
+      git clone https://github.com/sviehb/jefferson external/binwalk/jefferson
+      pip3 install -r ./external/binwalk/jefferson/requirements.txt
+      python3 ./external/binwalk/jefferson/setup.py install
+    else
+      echo -e "$GREEN""jefferson already installed""$NC"
+    fi
 
-      if ! command -v unstuff > /dev/null ; then
-        mkdir ./external/binwalk/unstuff
-        wget -O ./external/binwalk/unstuff/stuffit520.611linux-i386.tar.gz http://downloads.tuxfamily.org/sdtraces/stuffit520.611linux-i386.tar.gz
-        tar -zxv -f ./external/binwalk/unstuff/stuffit520.611linux-i386.tar.gz -C ./external/binwalk/unstuff
-        cp ./external/binwalk/unstuff/bin/unstuff /usr/local/bin/
-      else
-        echo -e "$GREEN""unstuff already installed""$NC"
-      fi
+    if ! command -v unstuff > /dev/null ; then
+      mkdir ./external/binwalk/unstuff
+      wget -O ./external/binwalk/unstuff/stuffit520.611linux-i386.tar.gz http://downloads.tuxfamily.org/sdtraces/stuffit520.611linux-i386.tar.gz
+      tar -zxv -f ./external/binwalk/unstuff/stuffit520.611linux-i386.tar.gz -C ./external/binwalk/unstuff
+      cp ./external/binwalk/unstuff/bin/unstuff /usr/local/bin/
+    else
+      echo -e "$GREEN""unstuff already installed""$NC"
+    fi
       
-      if ! command -v cramfsck > /dev/null ; then
-        if [[ -f "/opt/firmware-mod-kit/trunk/src/cramfs-2.x/cramfsck" ]]; then
-          ln -s /opt/firmware-mod-kit/trunk/src/cramfs-2.x/cramfsck /usr/bin/cramfsck
-        fi
-
-        git clone https://github.com/npitre/cramfs-tools external/binwalk/cramfs-tools
-        make -C ./external/binwalk/cramfs-tools/
-        install ./external/binwalk/cramfs-tools/mkcramfs /usr/local/bin
-        install ./external/binwalk/cramfs-tools/cramfsck /usr/local/bin
-      else
-        echo -e "$GREEN""cramfsck already installed""$NC"
+    if ! command -v cramfsck > /dev/null ; then
+      if [[ -f "/opt/firmware-mod-kit/trunk/src/cramfs-2.x/cramfsck" ]]; then
+        ln -s /opt/firmware-mod-kit/trunk/src/cramfs-2.x/cramfsck /usr/bin/cramfsck
       fi
 
+      git clone https://github.com/npitre/cramfs-tools external/binwalk/cramfs-tools
+      make -C ./external/binwalk/cramfs-tools/
+      install ./external/binwalk/cramfs-tools/mkcramfs /usr/local/bin
+      install ./external/binwalk/cramfs-tools/cramfsck /usr/local/bin
+    else
+      echo -e "$GREEN""cramfsck already installed""$NC"
+    fi
 
-      if ! command -v ubi_reader > /dev/null ; then
-        git clone https://github.com/jrspruitt/ubi_reader external/binwalk/ubi_reader
-        cd ./external/binwalk/ubi_reader || exit 1
-        git reset --hard 0955e6b95f07d849a182125919a1f2b6790d5b51
-        python2 setup.py install
-        cd .. || exit 1
-      else
-        echo -e "$GREEN""ubi_reader already installed""$NC"
-      fi
 
-      if ! command -v binwalk > /dev/null ; then
-        python3 setup.py install
-      else
-        echo -e "$GREEN""binwalk already installed""$NC"
-      fi
+    if ! command -v ubireader_extract_files > /dev/null ; then
+      git clone https://github.com/jrspruitt/ubi_reader external/binwalk/ubi_reader
+      cd ./external/binwalk/ubi_reader || exit 1
+      git reset --hard 0955e6b95f07d849a182125919a1f2b6790d5b51
+      python2 setup.py install
+      cd .. || exit 1
+    else
+      echo -e "$GREEN""ubi_reader already installed""$NC"
+    fi
 
-      cd ../.. || exit 1
+    if ! command -v binwalk > /dev/null ; then
+      python3 setup.py install
+    else
+      echo -e "$GREEN""binwalk already installed""$NC"
+      BINWALK_PRE_AVAILABLE=1
+    fi
 
-      #rm -rf ./external/binwalk
+    cd ../.. || exit 1
 
-      if [[ -f "/usr/local/bin/binwalk" ]] ; then
-        echo -e "$GREEN""binwalk installed successfully""$NC"
-      else
-        echo -e "$ORANGE""binwalk installation failed - check it manually""$NC"
-      fi
-    #fi
+    if [[ -f "/usr/local/bin/binwalk" && "$BINWALK_PRE_AVAILABLE" -eq 0 ]] ; then
+      echo -e "$GREEN""binwalk installed successfully""$NC"
+    elif [[ ! -f "/usr/local/bin/binwalk" && "$BINWALK_PRE_AVAILABLE" -eq 0 ]] ; then
+      echo -e "$ORANGE""binwalk installation failed - check it manually""$NC"
+    fi
   ;;
 esac
 

--- a/installer.sh
+++ b/installer.sh
@@ -580,7 +580,7 @@ case ${ANSWER:0:1} in
       fi
       case ${ANSWER:0:1} in
         y|Y )
-          cve_searchsploit -u
+          #cve_searchsploit -u
         ;;
       esac    
     fi
@@ -597,6 +597,7 @@ print_tool_info "python3-pyqt5" 1
 print_tool_info "python3-pyqt5.qtopengl" 1
 print_tool_info "python3-numpy" 1
 print_tool_info "python3-scipy" 1
+print_tool_info "python2" 1
 print_tool_info "mtd-utils" 1
 print_tool_info "gzip" 1
 print_tool_info "bzip2" 1
@@ -661,7 +662,9 @@ case ${ANSWER:0:1} in
     if ! command -v jefferson > /dev/null ; then
       git clone https://github.com/sviehb/jefferson external/binwalk/jefferson
       pip3 install -r ./external/binwalk/jefferson/requirements.txt
-      python3 ./external/binwalk/jefferson/setup.py install
+      cd ./external/binwalk/jefferson/ || exit 1
+      python3 ./setup.py install
+      cd ../../.. || exit 1
     else
       echo -e "$GREEN""jefferson already installed""$NC"
     fi

--- a/installer.sh
+++ b/installer.sh
@@ -592,7 +592,6 @@ esac
 
 INSTALL_APP_LIST=()
 print_tool_info "python3-pip" 1
-print_tool_info "python3-crypto" 1
 print_tool_info "python3-opengl" 1
 print_tool_info "python3-pyqt5" 1
 print_tool_info "python3-pyqt5.qtopengl" 1
@@ -617,8 +616,7 @@ print_tool_info "build-essential" 1
 print_tool_info "zlib1g-dev" 1
 print_tool_info "liblzma-dev" 1
 print_tool_info "liblzo2-dev" 1
-# print_tool_info "firmware-mod-kit" 1
-# This is no valid packet, couldn't be found
+print_tool_info "firmware-mod-kit" 1
 
 if [[ "$FORCE" -eq 0 ]] && [[ "$LIST_DEP" -eq 0 ]] ; then
   echo -e "\\n""$MAGENTA""$BOLD""Do you want to download and install binwalk, yaffshiv, sasquatch, jefferson, unstuff, cramfs-tools and ubi_reader (if not already on the system)?""$NC"
@@ -631,9 +629,6 @@ else
 fi
 case ${ANSWER:0:1} in
   y|Y )
-    if [[ -f "/usr/local/bin/binwalk" ]]; then
-      echo -e "Found binwalk. Skipping installation."
-    else
 
       apt-get install "${INSTALL_APP_LIST[@]}" -y
 
@@ -645,45 +640,77 @@ case ${ANSWER:0:1} in
 
       git clone https://github.com/ReFirmLabs/binwalk.git external/binwalk
 
-      git clone https://github.com/devttys0/yaffshiv external/binwalk/yaffshiv
-      sudo python3 ./external/binwalk/yaffshiv/setup.py install
+      if ! command -v yaffshiv1 > /dev/null ; then
+        git clone https://github.com/devttys0/yaffshiv external/binwalk/yaffshiv
+        python3 ./external/binwalk/yaffshiv/setup.py install
+      else
+        echo -e "$GREEN""yaffshiv already installed""$NC"
+      fi
 
-      git clone https://github.com/devttys0/sasquatch external/binwalk/sasquatch
-      sudo CFLAGS=-fcommon ./external/binwalk/sasquatch/build.sh -y
+      if ! command -v sasquatch > /dev/null ; then
+        git clone https://github.com/devttys0/sasquatch external/binwalk/sasquatch
+        CFLAGS=-fcommon ./external/binwalk/sasquatch/build.sh -y
+      else
+        echo -e "$GREEN""sasquatch already installed""$NC"
+      fi
 
-      git clone https://github.com/sviehb/jefferson external/binwalk/jefferson
-      sudo pip3 install -r ./external/binwalk/jefferson/requirements.txt
-      sudo python3 ./external/binwalk/jefferson/setup.py install
+      if ! command -v jefferson > /dev/null ; then
+        git clone https://github.com/sviehb/jefferson external/binwalk/jefferson
+        pip3 install -r ./external/binwalk/jefferson/requirements.txt
+        python3 ./external/binwalk/jefferson/setup.py install
+      else
+        echo -e "$GREEN""jefferson already installed""$NC"
+      fi
 
-      mkdir ./external/binwalk/unstuff
-      wget -O ./external/binwalk/unstuff/stuffit520.611linux-i386.tar.gz http://downloads.tuxfamily.org/sdtraces/stuffit520.611linux-i386.tar.gz
-      tar -zxv -f ./external/binwalk/unstuff/stuffit520.611linux-i386.tar.gz -C ./external/binwalk/unstuff
-      sudo cp ./external/binwalk/unstuff/bin/unstuff /usr/local/bin/
+      if ! command -v unstuff > /dev/null ; then
+        mkdir ./external/binwalk/unstuff
+        wget -O ./external/binwalk/unstuff/stuffit520.611linux-i386.tar.gz http://downloads.tuxfamily.org/sdtraces/stuffit520.611linux-i386.tar.gz
+        tar -zxv -f ./external/binwalk/unstuff/stuffit520.611linux-i386.tar.gz -C ./external/binwalk/unstuff
+        cp ./external/binwalk/unstuff/bin/unstuff /usr/local/bin/
+      else
+        echo -e "$GREEN""unstuff already installed""$NC"
+      fi
       
-      sudo ln -s /opt/firmware-mod-kit/trunk/src/cramfs-2.x/cramfsck /usr/bin/cramfsck
+      if ! command -v cramfsck > /dev/null ; then
+        if [[ -f "/opt/firmware-mod-kit/trunk/src/cramfs-2.x/cramfsck" ]]; then
+          ln -s /opt/firmware-mod-kit/trunk/src/cramfs-2.x/cramfsck /usr/bin/cramfsck
+        fi
 
-      git clone https://github.com/npitre/cramfs-tools external/binwalk/cramfs-tools
-      make -C ./external/binwalk/cramfs-tools/
-      install ./external/binwalk/cramfs-tools/mkcramfs /usr/local/bin
-      sudo install ./external/binwalk/cramfs-tools/cramfsck /usr/local/bin
+        git clone https://github.com/npitre/cramfs-tools external/binwalk/cramfs-tools
+        make -C ./external/binwalk/cramfs-tools/
+        install ./external/binwalk/cramfs-tools/mkcramfs /usr/local/bin
+        install ./external/binwalk/cramfs-tools/cramfsck /usr/local/bin
+      else
+        echo -e "$GREEN""cramfsck already installed""$NC"
+      fi
 
-      git clone https://github.com/jrspruitt/ubi_reader external/binwalk/ubi_reader
-      cd ./external/binwalk/ubi_reader || exit 1
-      git reset --hard 0955e6b95f07d849a182125919a1f2b6790d5b51
-      sudo python2 setup.py install
-      cd .. || exit 1
 
-      sudo python3 setup.py install
+      if ! command -v ubi_reader > /dev/null ; then
+        git clone https://github.com/jrspruitt/ubi_reader external/binwalk/ubi_reader
+        cd ./external/binwalk/ubi_reader || exit 1
+        git reset --hard 0955e6b95f07d849a182125919a1f2b6790d5b51
+        python2 setup.py install
+        cd .. || exit 1
+      else
+        echo -e "$GREEN""ubi_reader already installed""$NC"
+      fi
+
+      if ! command -v binwalk > /dev/null ; then
+        python3 setup.py install
+      else
+        echo -e "$GREEN""binwalk already installed""$NC"
+      fi
+
       cd ../.. || exit 1
 
-      rm -rf ./external/binwalk
+      #rm -rf ./external/binwalk
 
       if [[ -f "/usr/local/bin/binwalk" ]] ; then
         echo -e "$GREEN""binwalk installed successfully""$NC"
       else
         echo -e "$ORANGE""binwalk installation failed - check it manually""$NC"
       fi
-    fi
+    #fi
   ;;
 esac
 

--- a/installer.sh
+++ b/installer.sh
@@ -644,7 +644,7 @@ case ${ANSWER:0:1} in
 
     if ! command -v yaffshiv > /dev/null ; then
       git clone https://github.com/devttys0/yaffshiv external/binwalk/yaffshiv
-      cd ./external/binwalk/yaffshiv/
+      cd ./external/binwalk/yaffshiv/ || exit 1
       python3 setup.py install
       cd ../../.. || exit 1
     else

--- a/installer.sh
+++ b/installer.sh
@@ -706,7 +706,7 @@ case ${ANSWER:0:1} in
     fi
 
     if ! command -v binwalk > /dev/null ; then
-      cd ./external/binwalk
+      cd ./external/binwalk || exit 1
       python3 setup.py install
     else
       echo -e "$GREEN""binwalk already installed""$NC"

--- a/modules/F50_base_aggregator.sh
+++ b/modules/F50_base_aggregator.sh
@@ -85,6 +85,7 @@ output_overview() {
     if [[ -n "$PRE_ARCH" ]]; then
       print_output "[+] Detected architecture:""$ORANGE"" ""$PRE_ARCH"
       write_link "p07"
+      echo "architecture_verified;\"unknown\"" >> "$CSV_LOG_FILE"
       echo "architecture_unverified;\"$PRE_ARCH\"" >> "$CSV_LOG_FILE"
     fi
   fi
@@ -603,6 +604,7 @@ print_os() {
   else
     print_output "[+] Possible operating system detected (""$ORANGE""unverified$GREEN): $ORANGE$SYSTEM"
     write_link "p07"
+    echo "os_verified;\"unknown\"" >> "$CSV_LOG_FILE"
     echo "os_unverified;\"$SYSTEM\"" >> "$CSV_LOG_FILE"
   fi
 }

--- a/modules/S120_cwe_checker.sh
+++ b/modules/S120_cwe_checker.sh
@@ -25,7 +25,8 @@ S120_cwe_checker()
   module_log_init "${FUNCNAME[0]}"
   module_title "Check binaries with cwe-checker"
 
-  if [[ $CWE_CHECKER -eq 1 ]] ; then
+  # currently disabling in docker mode
+  if [[ $CWE_CHECKER -eq 1 && $IN_DOCKER -eq 0 ]] ; then
     cwe_check
     final_cwe_log "$TOTAL_CWE_CNT"
 
@@ -46,6 +47,7 @@ cwe_check() {
     if ( file "$LINE" | grep -q ELF ) ; then
       NAME=$(basename "$LINE")
       LINE=$(readlink -f "$LINE")
+      print_output "[*] Testing $LINE"
       readarray -t TEST_OUTPUT < <( docker run --rm -v "$LINE":/tmp/input fkiecad/cwe_checker /tmp/input | tee -a "$LOG_PATH_MODULE"/cwe_"$NAME".log )
       if [[ ${#TEST_OUTPUT[@]} -ne 0 ]] ; then
         print_output "[*] ""$(print_path "$LINE")"


### PR DESCRIPTION
This pull request includes some small improvements:
* installer should be able to handle all the binwalk installation more smart
* csv output helps embark
* for automated tests it typically makes no sense to store the extracted firmware for all tests - new option -r removes the extracted firmware
* in the emba.log for the web report we had no final timestamp - restructured the finish to get it into the web report
* s120 is now disabled in docker mode - this is just a quick fix and we need to take a deeper look at this issue