### PR TITLE
respect older kernel modules

### DIFF
--- a/modules/S25_kernel_check.sh
+++ b/modules/S25_kernel_check.sh
@@ -102,7 +102,7 @@ S25_kernel_check()
 }
 
 populate_karrays() {
-  mapfile -t KERNEL_MODULES < <( find "$FIRMWARE_PATH" "${EXCL_FIND[@]}" -xdev -iname "*.ko" -type f -exec md5sum {} \; 2>/dev/null | sort -u -k1,1 | cut -d\  -f3 )
+  mapfile -t KERNEL_MODULES < <( find "$FIRMWARE_PATH" "${EXCL_FIND[@]}" -xdev \( -iname "*.ko" -o -iname "*.o" \) -type f -exec md5sum {} \; 2>/dev/null | sort -u -k1,1 | cut -d\  -f3 )
   local KERNEL_VERSION_
 
   for K_MODULE in "${KERNEL_MODULES[@]}"; do


### PR DESCRIPTION
We have completely ignored older kernel modules in *.o format. This PR handles them regarding the path in s25.
We should take a deeper look on how to extract further details ...