### PR TITLE
revert redis pw change

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -1336,20 +1336,26 @@ if [[ "$LIST_DEP" -eq 1 ]] || [[ $IN_DOCKER -eq 1 ]] || [[ $DOCKER_SETUP -eq 1 ]
 
     # shellcheck disable=SC2002
     cat requirements.txt | xargs -n 1 pip install 2>/dev/null
-    REDIS_PW="$(tr -dc A-Za-z0-9 </dev/urandom | head -c 13)"
+
+    ## In our current setup it is not possible to change the redis password
+    ## external is in the container and so we leave this to default
+    #REDIS_PW="$(tr -dc A-Za-z0-9 </dev/urandom | head -c 13)"
 
     echo -e "[*] Setting up CVE-search environment - ./etc/configuration.ini"
     sed -zE 's/localhost([^\n]*\n[^\n]*27017)/172.36.0.1\1/' ./etc/configuration.ini.sample | tee ./etc/configuration.ini &>/dev/null
     # we do not use the web server. In case someone enables it we have a good default configuration in place:
     sed -i "s/^Debug:\ True/Debug:\ False/g" ./etc/configuration.ini
     sed -i "s/^LoginRequired:\ False/LoginRequired:\ True/g" ./etc/configuration.ini
+    sed -i 's/^\#\ requirepass\ .*/requirepass\ RedisPassword/g' /etc/redis/redis.conf
+    sed -i 's/^requirepass\ .*/requirepass\ RedisPassword/g' /etc/redis/redis.conf
 
-    echo -e "[*] Setting password for Redis environment - ./etc/configuration.ini"
-    sed -i "s/^Password:\ .*/Password:\ $REDIS_PW/g" ./etc/configuration.ini
-
-    echo -e "[*] Setting password for Redis environment - /etc/redis/redis.conf"
-    sed -i "s/^\#\ requirepass\ .*/requirepass\ $REDIS_PW/g" /etc/redis/redis.conf
-    sed -i "s/^requirepass\ .*/requirepass\ $REDIS_PW/g" /etc/redis/redis.conf
+    ## In our current setup it is not possible to change the redis password
+    ## external is in the container and so we leave this to default
+    #echo -e "[*] Setting password for Redis environment - ./etc/configuration.ini"
+    #sed -i "s/^Password:\ .*/Password:\ $REDIS_PW/g" ./etc/configuration.ini
+    #echo -e "[*] Setting password for Redis environment - /etc/redis/redis.conf"
+    #sed -i "s/^\#\ requirepass\ .*/requirepass\ $REDIS_PW/g" /etc/redis/redis.conf
+    #sed -i "s/^requirepass\ .*/requirepass\ $REDIS_PW/g" /etc/redis/redis.conf
   fi
    
   case ${ANSWER:0:1} in

--- a/modules/F10_license_summary.sh
+++ b/modules/F10_license_summary.sh
@@ -22,6 +22,7 @@ F10_license_summary() {
   module_log_init "${FUNCNAME[0]}"
   module_title "License inventory"
   pre_module_reporter "${FUNCNAME[0]}"
+  print_output ""
 
   COUNT_LIC=0
 

--- a/modules/F20_vul_aggregator.sh
+++ b/modules/F20_vul_aggregator.sh
@@ -21,6 +21,7 @@ F20_vul_aggregator() {
   module_title "Final vulnerability aggregator"
 
   pre_module_reporter "${FUNCNAME[0]}"
+  print_output ""
   
   mkdir "$LOG_PATH_MODULE"/cve_sum
   mkdir "$LOG_PATH_MODULE"/exploit


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
In PR https://github.com/e-m-b-a/emba/pull/213 I changed the redis PW during installation to a random value. As the EMBA external directory is included in our docker container we can't change the password during installation. My fault :)


* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**
Revert it to default password


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
The installer should be able to handle it. If someone already has issues it is possible to change the password manually in redis.conf and configuration.ini
