### PR TITLE
DLink-X-decryption

### DIFF
--- a/config/report_templates/P11_dlink_SHRS_enc_extract-post.sh
+++ b/config/report_templates/P11_dlink_SHRS_enc_extract-post.sh
@@ -2,8 +2,11 @@
 
 print_output "EMBA was able to identify an encrypted ${ORANGE}D'Link${NC} firmware image. This firmware image was protected with leaked key material and it is possible to decrypt the firmware for further analysis."
 print_output ""
-print_output "While EMBA is currently able to decrypt firmware with the header details ${ORANGE}SHRS${NC}, firmware with the header ${ORANGE}encrpted_img${NC} can't be decrypted by EMBA."
+print_output "While EMBA is currently able to decrypt firmware with the different header details, like ${ORANGE}SHRS${NC} and ${ORANGE}encrpted_img${NC}, others can't be decrypted by EMBA."
 if [[ "$DLINK_ENC_DETECTED" -eq 1 ]]; then
   print_output ""
   print_output "In the current case the original firmware was encrypted with the ${ORANGE}SHRS${NC} mechanism and was decrypted to ${ORANGE}$EXTRACTION_FILE${NC}"
+elif [[ "$DLINK_ENC_DETECTED" -eq 2 ]]; then
+  print_output ""
+  print_output "In the current case the original firmware was encrypted with the ${ORANGE}encrpted_img${NC} mechanism and was decrypted to ${ORANGE}$EXTRACTION_FILE${NC}"
 fi

--- a/modules/P11_dlink_SHRS_enc_extract.sh
+++ b/modules/P11_dlink_SHRS_enc_extract.sh
@@ -75,9 +75,9 @@ dlink_enc_img_extr(){
   dd if="$DLINK_ENC_PATH_" skip=16 iflag=skip_bytes of="$TMP_IMAGE_FILE" 2>&1 | tee -a "$LOG_FILE"
 
   IMAGE_SIZE=$(stat -c%s "$TMP_IMAGE_FILE")
-  let "ITERATIONS = $IMAGE_SIZE / 131072"
-  for ((ITERATION=0; ITERATION<$ITERATIONS; ITERATION++)); do
-    let "OFFSET = 131072 * $ITERATION"
+  (( ROOF=IMAGE_SIZE/131072 ))
+  for ((ITERATION=0; ITERATION<ROOF; ITERATION++)); do
+    (( OFFSET=131072*ITERATION ))
     dd if="$TMP_IMAGE_FILE" skip="$OFFSET" iflag=skip_bytes count=256| openssl aes-256-cbc -d -in /dev/stdin  -out /dev/stdout \
     -K "6865392d342b4d212964363d6d7e7765312c7132613364316e26322a5a5e2538" -iv "4a253169516c38243d6c6d2d3b384145" --nopad \
     --nosalt | dd if=/dev/stdin of="$EXTRACTION_FILE_" oflag=append conv=notrunc 2>&1 | tee -a "$LOG_FILE"

--- a/modules/P11_dlink_SHRS_enc_extract.sh
+++ b/modules/P11_dlink_SHRS_enc_extract.sh
@@ -15,7 +15,7 @@
 # Contributor: Benedikt Kuehne
 
 # Description: Extracts encrypted firmware images from D-Link
-# (See https://github.com/0xricksanchez/dlink-decrypt or TODO for more info)
+# (See https://github.com/0xricksanchez/dlink-decrypt)
 # Pre-checker threading mode - if set to 1, these modules will run in threaded mode
 export PRE_THREAD_ENA=0
 
@@ -61,7 +61,7 @@ dlink_SHRS_enc_extractor() {
   fi
 }
 
-dlink_enc_img_extr(){
+dlink_enc_img_extractor(){
   export TMP_DIR="$LOG_DIR""/tmp"
 
   local DLINK_ENC_PATH_="$1"
@@ -69,7 +69,6 @@ dlink_enc_img_extr(){
   local TMP_IMAGE_FILE="$TMP_DIR/image.bin"
 
   sub_module_title "DLink encrpted_image extractor"
-
 
   hexdump -C "$DLINK_ENC_PATH_" | head | tee -a "$LOG_FILE" || true
   dd if="$DLINK_ENC_PATH_" skip=16 iflag=skip_bytes of="$TMP_IMAGE_FILE" 2>&1 | tee -a "$LOG_FILE"

--- a/modules/P11_dlink_SHRS_enc_extract.sh
+++ b/modules/P11_dlink_SHRS_enc_extract.sh
@@ -62,8 +62,7 @@ dlink_SHRS_enc_extractor() {
 }
 
 dlink_enc_img_extractor(){
-  export TMP_DIR="$LOG_DIR""/tmp"
-
+  local TMP_DIR="$LOG_DIR""/tmp"
   local DLINK_ENC_PATH_="$1"
   local EXTRACTION_FILE_="$2"
   local TMP_IMAGE_FILE="$TMP_DIR/image.bin"

--- a/modules/P11_dlink_SHRS_enc_extract.sh
+++ b/modules/P11_dlink_SHRS_enc_extract.sh
@@ -31,7 +31,7 @@ P11_dlink_SHRS_enc_extract() {
     if [[ "$DLINK_ENC_DETECTED" -eq 1 ]]; then
       dlink_SHRS_enc_extractor "$FIRMWARE_PATH" "$EXTRACTION_FILE"
     elif [[ "$DLINK_ENC_DETECTED" -eq 2 ]]; then
-      dlink_enc_img_extr "$FIRMWARE_PATH" "$EXTRACTION_FILE"
+      dlink_enc_img_extractor "$FIRMWARE_PATH" "$EXTRACTION_FILE"
     fi
 
     NEG_LOG=1

--- a/modules/P60_firmware_bin_extractor.sh
+++ b/modules/P60_firmware_bin_extractor.sh
@@ -196,6 +196,9 @@ deeper_extractor_helper() {
       elif [[ "$DLINK_ENC_DETECTED" -eq 1 ]]; then
         dlink_SHRS_enc_extractor "$FILE_TMP" "${FILE_TMP}_shrs_extracted" &
         WAIT_PIDS_P20+=( "$!" )
+      elif [[ "$DLINK_ENC_DETECTED" -eq 2 ]]; then
+        dlink_enc_img_extractor "$FILE_TMP" "${FILE_TMP}_enc_img_extracted" &
+        WAIT_PIDS_P20+=( "$!" )
       elif [[ "$EXT_IMAGE" -eq 1 ]]; then
         ext2_extractor "$FILE_TMP" "${FILE_TMP}_ext_extracted" &
         WAIT_PIDS_P20+=( "$!" )


### PR DESCRIPTION
**?What kind of change does this PR introduce?**
---
-> Additions to the P11 Module (Dlink Firmware decryption)



**?What is the current behavior?**
---
-> Can not decrypt Dlink Firmwares with header `encrpted_img`


**?What is the new behavior (if this is a feature change)?**
---
-> Decryption and extraction of UBI-image from firmware binary  (tested on DIR-X1560,DIR-X1870 etc) 
![image](https://user-images.githubusercontent.com/62940240/157654475-4deb6d02-9db1-4d13-9554-5b34ec4acd62.png)
![image](https://user-images.githubusercontent.com/62940240/157806435-d7bd5f86-eac3-46f2-8bce-43d6e5042282.png)



**?Does this PR introduce a breaking change?**
---
-> No, just decryption capabilities
