### PR TITLE
Ubuntu-recommendations

### DIFF
--- a/emba.sh
+++ b/emba.sh
@@ -908,7 +908,10 @@ main()
     pkill -f "inotifywait.*$LOG_DIR.*"
   fi
   if [[ -f "$HTML_PATH"/index.html ]] && [[ "$IN_DOCKER" -eq 0 ]]; then
-    print_output "[*] Web report created HTML report in $ORANGE$LOG_DIR/html-report$NC\\n" "main" 
+    print_output "[*] Web report created HTML report in $ORANGE$LOG_DIR/html-report$NC\\n" "main"
+    if grep -q "PRETTY_NAME=\"Ubuntu" /etc/os-release 2>/dev/null && [[ "$LOG_DIR" = /home/* ]]; then
+      print_output "[!] Use $BLUE changeown <USER> $ORANGE$LOG_DIR $BLUE -R $NC\\n" "main"
+    fi
     print_output "[*] Open the web-report with$ORANGE firefox $(abs_path "$HTML_PATH/index.html")$NC\\n" "main"
   fi
 }

--- a/helpers/helpers_emba_dependency_check.sh
+++ b/helpers/helpers_emba_dependency_check.sh
@@ -87,7 +87,7 @@ check_docker_env() {
     if [[ "$WSL" -eq 1 ]]; then
       echo -e "$RED""    Is dockerd running (e.g., sudo dockerd --iptables=false &)""$NC"
     else
-      echo -e "$RED""    run \$docker-compose up --no-start to start or reset it otherwise (\$ docker network rm emba_runs)""$NC"
+      echo -e "$RED""    Use  \$systemctl restart NetworkManager docker or reset the docker interface manually (\$ docker network rm emba_runs)""$NC"
     fi
     DEP_ERROR=1
   else


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Two minor changes to recommendations. 


* **What is the current behavior?** (You can also link to an open issue here)
1. EMBA recommends docker-interface removal
2. html-report can't be accessed via firefox without changing ownership of the log-directory.(on Ubuntu)


* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**
1. change to service restart recommendation
2. Adding recommendation to set ownership manually if on Ubuntu (/home dirs are encrypted)


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nope