### PR TITLE
Restore ownership

### DIFF
--- a/emba.sh
+++ b/emba.sh
@@ -878,6 +878,8 @@ main()
 
   remove_status_bar
 
+  restore_permissions
+
   write_notification "Reporting phase ended"
 
   if [[ "$TESTING_DONE" -eq 1 ]]; then
@@ -909,9 +911,6 @@ main()
   fi
   if [[ -f "$HTML_PATH"/index.html ]] && [[ "$IN_DOCKER" -eq 0 ]]; then
     print_output "[*] Web report created HTML report in $ORANGE$LOG_DIR/html-report$NC\\n" "main"
-    if grep -q "PRETTY_NAME=\"Ubuntu" /etc/os-release 2>/dev/null && [[ "$LOG_DIR" = /home/* ]]; then
-      print_output "[!] Use $BLUE changeown <USER> $ORANGE$LOG_DIR $BLUE -R $NC\\n" "main"
-    fi
     print_output "[*] Open the web-report with$ORANGE firefox $(abs_path "$HTML_PATH/index.html")$NC\\n" "main"
   fi
 }

--- a/helpers/helpers_emba_helpers.sh
+++ b/helpers/helpers_emba_helpers.sh
@@ -235,5 +235,5 @@ disable_strict_mode() {
 
 restore_permissions() {
   print_output "[*] Restoring directory permissions" "no_log"
-  chown ${SUDO_USER:-${USER}}:$(id "${SUDO_USER:-${USER}}" -g ) "$LOG_DIR" -R
+  chown "${SUDO_USER:-${USER}}":"$(id "${SUDO_USER:-${USER}}" -g)" "$LOG_DIR" -R
 }

--- a/helpers/helpers_emba_helpers.sh
+++ b/helpers/helpers_emba_helpers.sh
@@ -234,6 +234,6 @@ disable_strict_mode() {
 }
 
 restore_permissions() {
-  print_output "[*] Restoring directory permissions" "no_log"
+  print_output "[*] Restoring directory permissions for user:"${SUDO_USER:-${USER}}"" "no_log"
   chown "${SUDO_USER:-${USER}}":"$(id "${SUDO_USER:-${USER}}" -g)" "$LOG_DIR" -R
 }

--- a/helpers/helpers_emba_helpers.sh
+++ b/helpers/helpers_emba_helpers.sh
@@ -234,6 +234,6 @@ disable_strict_mode() {
 }
 
 restore_permissions() {
-  print_output "[*] Restoring directory permissions for user:"${SUDO_USER:-${USER}}"" "no_log"
+  print_output "[*] Restoring directory permissions for user: $ORANGE${SUDO_USER:-${USER}}$NC" "no_log"
   chown "${SUDO_USER:-${USER}}":"$(id "${SUDO_USER:-${USER}}" -g)" "$LOG_DIR" -R
 }

--- a/helpers/helpers_emba_helpers.sh
+++ b/helpers/helpers_emba_helpers.sh
@@ -232,3 +232,8 @@ disable_strict_mode() {
     fi
   fi
 }
+
+restore_permissions() {
+  print_output "[*] Restoring directory permissions" "no_log"
+  chown ${SUDO_USER:-${USER}}:$(id "${SUDO_USER:-${USER}}" -g ) "$LOG_DIR" -R
+}

--- a/installer.sh
+++ b/installer.sh
@@ -137,7 +137,8 @@ if ! grep -q "ID_LIKE=debian" /etc/os-release 2>/dev/null ; then
   print_help
   exit 1
 elif ! grep -q "kali" /etc/debian_version 2>/dev/null ; then
-  if grep -q "PRETTY_NAME=\"Ubuntu 22.04 LTS\"" /etc/os-release 2>/dev/null ; then
+  if grep -q "VERSION_ID=\"22.04\"" /etc/os-release 2>/dev/null ; then 
+  # How to handle sub-versioning ? if grep -q -E "PRETTY_NAME=\"Ubuntu\ 22\.04(\.[0-9]+)?\ LTS\"" /etc/os-release 2>/dev/null ; then
     OTHER_OS=1
     UBUNTU_OS=1
   elif grep -q "PRETTY_NAME=\"Ubuntu 20.04 LTS\"" /etc/os-release 2>/dev/null ; then


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
--------------
   Restore Log-Directory ownership to calling user
   Fix Ubuntu 22.04 detection


**What is the current behavior?** (You can also link to an open issue here)
--------------
Directory is owned by root, which prevents access on Ubuntu.
Ubuntu 22.04.1 is not recognized as supported.

**What is the new behavior (if this is a feature change)? If possible add a screenshot.**
--------------
Calling user obtains ownership of all logs.
Support for Ubuntu 22.04 subversion

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
--------------
❎ 

**Other information**:
--------------
related to https://github.com/e-m-b-a/emba/pull/279