### PR TITLE
Limit check to modules directory

### DIFF
--- a/helpers/helpers_emba_html_generator.sh
+++ b/helpers/helpers_emba_html_generator.sh
@@ -138,7 +138,7 @@ add_link_tags() {
           REF_LINK="$(echo "$REF_LINK" | cut -d"#" -f1 || true)"
         fi
         # link modules
-        readarray -t MODUL_ARR_LINK < <( find . \( -iname "$REF_LINK""_*" ! -iname "*pre.sh" ! -iname "*post.sh" \) || true )
+        readarray -t MODUL_ARR_LINK < <( find ./modules \( -iname "$REF_LINK""_*.sh" ! -iname "*pre.sh" ! -iname "*post.sh" \) || true )
         if [[ "${#MODUL_ARR_LINK[@]}" -gt 0 ]] ; then
           MODUL_ARR_LINK_E="$(echo "${MODUL_ARR_LINK[0]}" | tr '[:upper:]' '[:lower:]' || true)"
           if [[ -n "$REF_ANCHOR" ]] ; then


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Easy fix.

* **What is the current behavior?** (You can also link to an open issue here)

@n0x08 created the issue #297 because after running EMBA with the log dir set inside the EMBA directory he found out, that the reference links to some other modules were wrong in the webreport.

Why? It is possible to add `[REF]` tags to modules in the output of EMBA and the webreport generation script checks then for the modules (previously in the main directory of EMBA with ignoring of the file ending) if they exists. There it found the old log files instead of the modules and linked to them and therefore created the mess. 

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

No wrong links anymore if there are old log files in the EMBA directory.