### PR TITLE
Kernel config extraction in S24

### DIFF
--- a/emba.sh
+++ b/emba.sh
@@ -775,7 +775,7 @@ main()
         if ! [[ -d "$LOG_DIR" ]] ; then
           mkdir "$LOG_DIR" || true
         fi
-        S25_kernel_check
+        check_kconfig
         exit 0
       fi
     fi

--- a/emba.sh
+++ b/emba.sh
@@ -775,7 +775,8 @@ main()
         if ! [[ -d "$LOG_DIR" ]] ; then
           mkdir "$LOG_DIR" || true
         fi
-        check_kconfig
+        # check_kconfig
+        print_output "[!] Currently not supported"
         exit 0
       fi
     fi

--- a/modules/F20_vul_aggregator.sh
+++ b/modules/F20_vul_aggregator.sh
@@ -465,14 +465,18 @@ cve_db_lookup_cve () {
   print_output "[*] CVE database lookup with CVE information: ${ORANGE}$CVE_ENTRY${NC}" "no_log"
 
   # CVE search:
-  set +e
+  if [[ "$STRICT_MODE" -eq 1 ]]; then
+    set +e
+  fi
   "$PATH_CVE_SEARCH" -c "$CVE_ENTRY" -o json | jq -rc '"\(.id):\(.cvss):\(.cvss3)"' | sort -t ':' -k3 -r > "$LOG_PATH_MODULE"/"$CVE_ENTRY".txt || true
 
   # shellcheck disable=SC2181
   if [[ "$?" -ne 0 ]]; then
     "$PATH_CVE_SEARCH" -c "$CVE_ENTRY" -o json | jq -rc '"\(.id):\(.cvss):\(.cvss3)"' | sort -t ':' -k3 -r > "$LOG_PATH_MODULE"/"$CVE_ENTRY".txt || true
   fi
-  set -e
+  if [[ "$STRICT_MODE" -eq 1 ]]; then
+    set -e
+  fi
 
   if [[ "$THREADED" -eq 1 ]]; then
     cve_extractor "$CVE_ENTRY" &

--- a/modules/L30_routersploit.sh
+++ b/modules/L30_routersploit.sh
@@ -64,11 +64,13 @@ check_live_routersploit() {
   if grep -q "Target is vulnerable" "$LOG_PATH_MODULE"/routersploit-"$IP_ADDRESS_".txt; then
     print_output "[+] Found the following vulnerabilities:" "" "$LOG_PATH_MODULE/routersploit-$IP_ADDRESS_.txt"
     grep -B 1 "Target is vulnerable" "$LOG_PATH_MODULE"/routersploit-"$IP_ADDRESS_".txt | tee -a "$LOG_FILE"
+    print_ln
   fi
   if grep -q "Target seems to be vulnerable" "$LOG_PATH_MODULE"/routersploit-"$IP_ADDRESS_".txt; then
     print_ln
     print_output "[+] Found the following possible vulnerabilities:" "" "$LOG_PATH_MODULE/routersploit-$IP_ADDRESS_.txt"
     grep -B 1 "Target seems to be vulnerable" "$LOG_PATH_MODULE"/routersploit-"$IP_ADDRESS_".txt | tee -a "$LOG_FILE"
+    print_ln
   fi
   print_output "[*] Routersploit tests for emulated system with IP $ORANGE$IP_ADDRESS_$NC finished"
 }

--- a/modules/P05_patools_init.sh
+++ b/modules/P05_patools_init.sh
@@ -55,9 +55,16 @@ patools_extractor() {
 
   FIRMWARE_NAME_="$(basename "$FIRMWARE_PATH_")"
 
-  set +e
+  if [[ "$STRICT_MODE" -eq 1 ]]; then
+    set +e
+  fi
+
   patool -v test "$FIRMWARE_PATH_" | tee -a "$LOG_PATH_MODULE"/paextract_test_"$FIRMWARE_NAME_".log
-  set -e
+
+  if [[ "$STRICT_MODE" -eq 1 ]]; then
+    set -e
+  fi
+
   cat "$LOG_PATH_MODULE"/paextract_test_"$FIRMWARE_NAME_".log >> "$LOG_FILE"
 
   if ! [[ -d "$EXTRACTION_DIR_" ]]; then

--- a/modules/P59_binwalk_extractor.sh
+++ b/modules/P59_binwalk_extractor.sh
@@ -45,6 +45,7 @@ P59_binwalk_extractor() {
   BINS=$(find "$FIRMWARE_PATH_CP" "${EXCL_FIND[@]}" -xdev -type f -exec file {} \; | grep -c "ELF" || true)
 
   if [[ "$BINS" -gt 0 || "$UNIQUE_FILES" -gt 0 ]]; then
+    sub_module_title "Firmware extraction details"
     linux_basic_identification_helper "$FIRMWARE_PATH_CP"
     print_ln
     print_output "[*] Found $ORANGE$FILES_EXT$NC files ($ORANGE$UNIQUE_FILES$NC unique files) and $ORANGE$DIRS_EXT$NC directories at all."

--- a/modules/P61_unblob_eval.sh
+++ b/modules/P61_unblob_eval.sh
@@ -71,7 +71,7 @@ P61_unblob_eval() {
   BINS_UB=$(find "$OUTPUT_DIR_UNBLOB" "${EXCL_FIND[@]}" -xdev -type f -exec file {} \; | grep -c "ELF" || true)
 
   if [[ "$BINS_UB" -gt 0 ]] || [[ "$FILES_EXT_UB" -gt 0 ]]; then
-    print_bar
+    sub_module_title "Firmware extraction details"
     print_output "[*] ${ORANGE}Unblob$NC results:"
     print_output "[*] Found $ORANGE$FILES_EXT_UB$NC files ($ORANGE$UNIQUE_FILES_UB$NC unique files) and $ORANGE$DIRS_EXT_UB$NC directories at all."
     print_output "[*] Found $ORANGE$BINS_UB$NC binaries."

--- a/modules/S06_distribution_identification.sh
+++ b/modules/S06_distribution_identification.sh
@@ -58,7 +58,7 @@ S06_distribution_identification()
           fi
 
           # check if not zero and not only spaces
-          if [[ -n "${IDENTIFIER// }" ]]; then
+          if [[ -n "${IDENTIFIER// }" ]] && [[ "$IDENTIFIER" == *[0-9]* ]]; then
             if [[ -n "$DLINK_FW_VER" ]]; then
               print_output "[+] Version information found $ORANGE$IDENTIFIER$GREEN in file $ORANGE$(print_path "$FILE")$GREEN for D-Link device."
               get_csv_rule_distri "$IDENTIFIER"
@@ -128,7 +128,7 @@ get_csv_rule_distri() {
   VERSION_IDENTIFIER="$(echo "$VERSION_IDENTIFIER" | sed -r 's/(openwrt)\ (kamikaze)\ r1[4-8][0-9][0-9][0-9].*/\1:\2:8.09/')"
   VERSION_IDENTIFIER="$(echo "$VERSION_IDENTIFIER" | sed -r 's/(openwrt)\ (backfire)\ r2[0-9][0-9][0-9][0-9].*/\1:\2:10.03/')"
   # OpenWrt 18.06.2 r7676-cddd7b4c77
-  VERSION_IDENTIFIER="$(echo "$VERSION_IDENTIFIER" | sed -r 's/(openwrt)\ ([0-9]+\.[0-9]+\.[0-9])\ (r[0-9]+\-)([a-z0-9]+).*/openwrt:\2/')"
+  VERSION_IDENTIFIER="$(echo "$VERSION_IDENTIFIER" | sed -r 's/(openwrt)\ ([0-9]+\.[0-9]+\.[0-9]+)\ (r[0-9]+\-[a-z0-9]+).*/openwrt:\2:\3/')"
   VERSION_IDENTIFIER="$(echo "$VERSION_IDENTIFIER" | sed -r 's/lede\ ([0-9]+\.[0-9]+\.[0-9]+)(-)?(rc[0-9])?.*/openwrt:\1:\3/')"
   VERSION_IDENTIFIER="$(echo "$VERSION_IDENTIFIER" | sed -r 's/openwrt\ ([0-9]+\.[0-9]+)/openwrt:\1/')"
   # OpenWrt Attitude Adjustment r7549 -> 12.09
@@ -137,7 +137,7 @@ get_csv_rule_distri() {
   VERSION_IDENTIFIER="$(echo "$VERSION_IDENTIFIER" | sed -r 's/d-link\ (.*)\ v([0-9].[0-9]+[a-z][0-9]+)/dlink:\1_firmware:\2/')"
   VERSION_IDENTIFIER="$(echo "$VERSION_IDENTIFIER" | sed -r 's/d-link\ (.*)\ v([0-9].[0-9]+)/dlink:\1_firmware:\2/')"
   # dd-wrt v24-sp2
-  VERSION_IDENTIFIER="$(echo "$VERSION_IDENTIFIER" | sed -r 's/dd-wrt\ v([0-9]+)(-sp[0-9])?/dd-wrt:dd-wrt:\1:\2/')"
+  VERSION_IDENTIFIER="$(echo "$VERSION_IDENTIFIER" | sed -r 's/dd-wrt\ v([0-9]+)-?(sp[0-9])?/dd-wrt:dd-wrt:\1:\2/')"
   VERSION_IDENTIFIER="$(echo "$VERSION_IDENTIFIER" | sed -r 's/dd-wrt\ \#([0-9]+)/dd-wrt:dd-wrt:\1/')"
   # iotgoat v1.0
   VERSION_IDENTIFIER="$(echo "$VERSION_IDENTIFIER" | sed -r 's/iotgoat\ v([0-9]\.[0-9]+)/iotgoat:\1/')"
@@ -146,5 +146,6 @@ get_csv_rule_distri() {
   VERSION_IDENTIFIER="$(echo "$VERSION_IDENTIFIER" | sed -r 's/big-ip\ asm\ ([0-9]+(\.[0-9]+)+?)/f5:big-ip_application_security_manager:\1/')"
   # Buildroot 2022.01.01
   VERSION_IDENTIFIER="$(echo "$VERSION_IDENTIFIER" | sed -r 's/buildroot\ ([0-9]+(\.[0-9]+)+?)/buildroot:\1/')"
+  VERSION_IDENTIFIER="${VERSION_IDENTIFIER// /:}"
   CSV_RULE="$VERSION_IDENTIFIER"
 }

--- a/modules/S115_usermode_emulator.sh
+++ b/modules/S115_usermode_emulator.sh
@@ -462,7 +462,7 @@ emulate_strace_run() {
 
   if [[ "${#MISSING_AREAS[@]}" -gt 0 ]]; then
     for MISSING_AREA in "${MISSING_AREAS[@]}"; do
-      if [[ "$MISSING_AREA" != */proc/* || "$MISSING_AREA" != */sys/* ]]; then
+      if [[ "$MISSING_AREA" != */proc/* || "$MISSING_AREA" != */sys/* || "$MISSING_AREA" != */dev/* ]]; then
         write_log "[*] Found missing area: $ORANGE$MISSING_AREA$NC" "$LOG_FILE_STRACER"
 
         FILENAME_MISSING=$(basename "$MISSING_AREA")

--- a/modules/S13_weak_func_check.sh
+++ b/modules/S13_weak_func_check.sh
@@ -171,7 +171,7 @@ function_check_NIOS2(){
         "$OBJDUMP" -d "$BINARY_" | grep -E -A 2 -B 20 "call.*$FUNC_ADDR" 2> /dev/null >> "$FUNC_LOG" || true
       fi
       if [[ -f "$FUNC_LOG" ]] && [[ $(wc -l "$FUNC_LOG" | awk '{print $1}') -gt 0 ]] ; then
-        sed -i -r "s/^.*($FUNC_ADDR).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
+        sed -i -r "s/^.*:.*($FUNC_ADDR).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
         COUNT_FUNC="$(grep -c "call.*""$FUNC_ADDR" "$FUNC_LOG"  2> /dev/null || true)"
         if [[ "$FUNCTION" == "strcpy" ]] ; then
           COUNT_STRLEN=$(grep -c "call.*$STRLEN_ADDR" "$FUNC_LOG"  2> /dev/null || true)
@@ -212,7 +212,7 @@ function_check_PPC32(){
         "$OBJDUMP" -d "$BINARY_" | grep -E -A 2 -B 20 "bl.*<$FUNCTION" 2> /dev/null >> "$FUNC_LOG" || true
       fi
       if [[ -f "$FUNC_LOG" ]] && [[ $(wc -l "$FUNC_LOG" | awk '{print $1}') -gt 0 ]] ; then
-        sed -i -r "s/^.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
+        sed -i -r "s/^.*:.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
         COUNT_FUNC="$(grep -c "bl.*""$FUNCTION" "$FUNC_LOG"  2> /dev/null || true)"
         if [[ "$FUNCTION" == "strcpy" ]] ; then
           COUNT_STRLEN=$(grep -c "bl.*strlen" "$FUNC_LOG"  2> /dev/null || true)
@@ -256,7 +256,7 @@ function_check_MIPS32() {
         "$OBJDUMP" -d "$BINARY_" | grep -A 2 -B 25 "$FUNC_ADDR""(gp)" | sed s/-"$FUNC_ADDR"\(gp\)/"$FUNCTION"/ | sed s/-"$STRLEN_ADDR"\(gp\)/strlen/ >> "$FUNC_LOG" || true
       fi
       if [[ -f "$FUNC_LOG" ]] && [[ $(wc -l "$FUNC_LOG" | awk '{print $1}') -gt 0 ]] ; then
-        sed -i -r "s/^.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
+        sed -i -r "s/^.*:.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
         COUNT_FUNC="$(grep -c "lw.*""$FUNCTION" "$FUNC_LOG" 2> /dev/null || true)"
         if [[ "$FUNCTION" == "strcpy" ]] ; then
           COUNT_STRLEN=$(grep -c "lw.*strlen" "$FUNC_LOG" 2> /dev/null || true)
@@ -294,7 +294,7 @@ function_check_ARM64() {
       "$OBJDUMP" -d "$BINARY_" | grep -A 2 -B 20 "[[:blank:]]bl[[:blank:]].*<$FUNCTION" 2> /dev/null >> "$FUNC_LOG" || true
     fi
     if [[ -f "$FUNC_LOG" ]] && [[ $(wc -l "$FUNC_LOG" | awk '{print $1}') -gt 0 ]] ; then
-      sed -i -r "s/^.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
+      sed -i -r "s/^.*:.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
       COUNT_FUNC="$(grep -c "[[:blank:]]bl[[:blank:]].*<$FUNCTION" "$FUNC_LOG"  2> /dev/null || true)"
       if [[ "$FUNCTION" == "strcpy" ]] ; then
         COUNT_STRLEN=$(grep -c "[[:blank:]]bl[[:blank:]].*<strlen" "$FUNC_LOG"  2> /dev/null || true)
@@ -332,7 +332,7 @@ function_check_ARM32() {
       "$OBJDUMP" -d "$BINARY_" | grep -A 2 -B 20 "[[:blank:]]bl[[:blank:]].*<$FUNCTION" 2> /dev/null >> "$FUNC_LOG" || true
     fi
     if [[ -f "$FUNC_LOG" ]] && [[ $(wc -l "$FUNC_LOG" | awk '{print $1}') -gt 0 ]] ; then
-      sed -i -r "s/^.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
+      sed -i -r "s/^.*:.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
       COUNT_FUNC="$(grep -c "[[:blank:]]bl[[:blank:]].*<$FUNCTION" "$FUNC_LOG"  2> /dev/null || true)"
       if [[ "$FUNCTION" == "strcpy" ]] ; then
         COUNT_STRLEN=$(grep -c "[[:blank:]]bl[[:blank:]].*<strlen" "$FUNC_LOG"  2> /dev/null || true)
@@ -371,7 +371,7 @@ function_check_x86() {
         "$OBJDUMP" -d "$BINARY_" | grep -E -A 2 -B 20 "call.*<$FUNCTION" 2> /dev/null >> "$FUNC_LOG" || true
       fi
       if [[ -f "$FUNC_LOG" ]] && [[ $(wc -l "$FUNC_LOG" | awk '{print $1}') -gt 0 ]] ; then
-        sed -i -r "s/^.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
+        sed -i -r "s/^.*:.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
         COUNT_FUNC="$(grep -c -e "call.*$FUNCTION" "$FUNC_LOG"  2> /dev/null || true)"
         if [[ "$FUNCTION" == "strcpy" ]] ; then
           COUNT_STRLEN=$(grep -c "call.*strlen" "$FUNC_LOG"  2> /dev/null || true)
@@ -410,7 +410,7 @@ function_check_x86_64() {
         "$OBJDUMP" -d "$BINARY_" | grep -E -A 2 -B 20 "call.*<$FUNCTION" 2> /dev/null >> "$FUNC_LOG" || true
       fi
       if [[ -f "$FUNC_LOG" ]] && [[ $(wc -l "$FUNC_LOG" | awk '{print $1}') -gt 0 ]] ; then
-        sed -i -r "s/^.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
+        sed -i -r "s/^.*:.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
         COUNT_FUNC="$(grep -c -e "call.*$FUNCTION" "$FUNC_LOG"  2> /dev/null || true)"
         if [[ "$FUNCTION" == "strcpy"  ]] ; then
           COUNT_STRLEN=$(grep -c "call.*strlen" "$FUNC_LOG"  2> /dev/null || true)
@@ -469,6 +469,7 @@ print_top10_statistics() {
             write_link "$LOG_PATH_MODULE""/vul_func_""$F_COUNTER""_""$FUNCTION"-"$SEARCH_TERM"".txt"
           fi
         done
+        print_ln
       fi  
     done
   else
@@ -489,7 +490,7 @@ log_bin_hardening() {
     write_log "  $HEAD_BIN_PROT" "$FUNC_LOG"
     # get binary entry
     BIN_PROT=$(grep '/'"$NAME"' ' "$LOG_DIR"/s12_binary_protection.txt | sed 's/Symbols.*/Symbols/' | sort -u || true)
-    write_log "  $BIN_PROT" "$FUNC_LOG"
+    write_log "  $BIN_PROT$NC" "$FUNC_LOG"
     write_log "" "$FUNC_LOG"
   fi
 }
@@ -507,7 +508,7 @@ log_func_footer() {
   local NAME="${1:-}"
   local FUNCTION="${2:-}"
 
-  write_log "" "$FUNC_LOG"
+  write_log "\n$NC" "$FUNC_LOG"
   write_log "[*] Function $ORANGE$FUNCTION$NC used $ORANGE$COUNT_FUNC$NC times $ORANGE$NAME$NC" "$FUNC_LOG"
   write_log "" "$FUNC_LOG"
 }

--- a/modules/S24_kernel_bin_identifier.sh
+++ b/modules/S24_kernel_bin_identifier.sh
@@ -26,6 +26,9 @@ S24_kernel_bin_identifier()
   local FILE=""
   local K_VER=""
   local K_INIT=""
+  local CFG_MD5=""
+  export KCFG_MD5=()
+
   if [[ -e "$EXT_DIR"/kconfig-hardened-check/bin/kconfig-hardened-check ]]; then
     KCONF_HARD_CHECKER="$EXT_DIR/kconfig-hardened-check/bin/kconfig-hardened-check"
   else
@@ -43,6 +46,7 @@ S24_kernel_bin_identifier()
     K_VER=$(strings "$FILE" 2>/dev/null | grep -E "^Linux version [0-9]+\.[0-9]+" || true)
 
     if [[ "$K_VER" =~ Linux\ version\ .* ]]; then
+      print_ln
       print_output "[+] Possible Linux Kernel found: $ORANGE$FILE$NC"
       print_ln
       print_output "$(indent "$(orange "$K_VER")")"
@@ -73,31 +77,184 @@ S24_kernel_bin_identifier()
         print_ln
       fi
 
+      disable_strict_mode "$STRICT_MODE" 0
+      extract_kconfig "$FILE"
+      enable_strict_mode "$STRICT_MODE" 0
+
+      # double check we really have a Kernel config extracted
+      if [[ -f "$KCONFIG_EXTRACTED" ]] && [[ $(grep -c CONFIG_ "$KCONFIG_EXTRACTED") -gt 50 ]]; then
+        CFG_CNT=$(grep -c CONFIG_ "$KCONFIG_EXTRACTED")
+        print_output "[+] Extracted kernel configuration ($ORANGE$CFG_CNT configuration entries$GREEN) from $ORANGE$(basename "$FILE")$NC" "" "$KCONFIG_EXTRACTED"
+        check_kconfig "$KCONFIG_EXTRACTED"
+      fi
+
       write_csv_log "$K_VER" "$FILE" "$K_INIT"
       NEG_LOG=1
 
     # ASCII kernel config files:
     elif file "$FILE" | grep -q "ASCII"; then
-      K_CON_DET=$(strings "$FILE" 2>/dev/null | grep -E "^# Linux.*[0-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}.* Kernel Configuration" || true)
-      if [[ "$K_CON_DET" =~ \ Kernel\ Configuration ]]; then
-        print_output "[+] Found kernel configuration file: $ORANGE$FILE$NC"
-        if [[ "$KCONF_HARD_CHECKER" != "NA" ]]; then
-          print_output "[*] Testing kernel configuration file $ORANGE$FILE$NC with kconfig-hardened-check"
-          local KCONF_LOG=""
-          KCONF_LOG="$LOG_PATH_MODULE/kconfig_hardening_check_$(basename "$FILE").log"
-          "$KCONF_HARD_CHECKER" -c "$FILE" | tee -a "$KCONF_LOG"
-          if [[ -f "$KCONF_LOG" ]]; then
-            FAILED_KSETTINGS=$(grep -c "FAIL: " "$KCONF_LOG")
-            if [[ "$FAILED_KSETTINGS" -gt 0 ]]; then
-              print_output "[+] Found $ORANGE$FAILED_KSETTINGS$GREEN security related kernel settings which should be reviewed - $ORANGE$(print_path "$FILE")$NC"
-              write_log "[*] Statistics:$FAILED_KSETTINGS"
-            fi
-          fi
+      CFG_MD5=$(md5sum "$FILE" | awk '{print $1}')
+      if [[ ! " ${KCFG_MD5[*]} " =~ ${CFG_MD5} ]]; then
+        K_CON_DET=$(strings "$FILE" 2>/dev/null | grep -E "^# Linux.*[0-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}.* Kernel Configuration" || true)
+        if [[ "$K_CON_DET" =~ \ Kernel\ Configuration ]]; then
+          print_ln
+          print_output "[+] Found kernel configuration file: $ORANGE$FILE$NC"
+          check_kconfig "$FILE"
+          NEG_LOG=1
+          KCFG_MD5+=("$CFG_MD5")
         fi
-        NEG_LOG=1
       fi
     fi
   done
 
   module_end_log "${FUNCNAME[0]}" "$NEG_LOG"
+}
+
+extract_kconfig() {
+  # Source: https://raw.githubusercontent.com/torvalds/linux/master/scripts/extract-ikconfig
+  # # extract-ikconfig - Extract the .config file from a kernel image
+  #
+  # This will only work when the kernel was compiled with CONFIG_IKCONFIG.
+  #
+  # The obscure use of the "tr" filter is to work around older versions of
+  # "grep" that report the byte offset of the line instead of the pattern.
+  #
+  # (c) 2009,2010 Dick Streefland <dick@streefland.net>
+  # Licensed under the terms of the GNU General Public License.
+
+  # Check invocation:
+  export IMG="${1:-}"
+  export KCONFIG_EXTRACTED=""
+
+  if ! [[ -f "$IMG" ]]; then
+    print_output "[-] No kernel file to analyze here - $ORANGE$IMG$NC"
+    return
+  fi
+
+  print_output "[*] Trying to extract kernel configuration from $ORANGE$IMG$NC"
+
+  export CF1='IKCFG_ST\037\213\010'
+  export CF2='0123456789'
+
+  # Prepare temp files:
+  export TMP1="$TMP_DIR"/ikconfig$$.1
+  export TMP2="$TMP_DIR"/ikconfig$$.2
+  # shellcheck disable=SC2064
+  trap "rm -f $TMP1 $TMP2" 0
+
+  # Initial attempt for uncompressed images or objects:
+  dump_config "$IMG"
+  if [[ $? -eq 4 ]]; then
+    return
+  fi
+
+  # That didn't work, so retry after decompression.
+  try_decompress '\037\213\010' xy    gunzip
+  if [[ $? -eq 4 ]]; then
+    return
+  fi
+
+  try_decompress '\3757zXZ\000' abcde unxz
+  if [[ $? -eq 4 ]]; then
+    return
+  fi
+
+  try_decompress 'BZh'          xy    bunzip2
+  if [[ $? -eq 4 ]]; then
+    return
+  fi
+
+  try_decompress '\135\0\0\0'   xxx   unlzma
+  if [[ $? -eq 4 ]]; then
+    return
+  fi
+
+  try_decompress '\211\114\132' xy    'lzop -d'
+  if [[ $? -eq 4 ]]; then
+    return
+  fi
+
+  try_decompress '\002\041\114\030' xyy 'lz4 -d -l'
+  if [[ $? -eq 4 ]]; then
+    return
+  fi
+
+  try_decompress '\050\265\057\375' xxx unzstd
+  if [[ $? -eq 4 ]]; then
+    return
+  fi
+}
+
+dump_config() {
+  # Source: https://raw.githubusercontent.com/torvalds/linux/master/scripts/extract-ikconfig
+  local IMG_="${1:-}"
+  local CFG_MD5=""
+
+  if ! [[ -f "$IMG_" ]]; then
+    print_output "[-] No kernel file to analyze here - $ORANGE$IMG_$NC"
+    return
+  fi
+
+  if POS=$(tr "$CF1\n$CF2" "\n$CF2=" < "$IMG_" | grep -abo "^$CF2"); then
+    POS=${POS%%:*}
+
+    tail -c+"$((POS + 8))" "$IMG_" | zcat > "$TMP1" 2> /dev/null
+
+    if [[ $? != 1 ]]; then  # exit status must be 0 or 2 (trailing garbage warning)
+      if [[ "$STRICT_MODE" -eq 1 ]]; then
+        set +e
+      fi
+
+      if ! [[ -f "$TMP1" ]]; then
+        return
+      fi
+
+      CFG_MD5=$(md5sum "$TMP1" | awk '{print $1}')
+      if [[ ! " ${KCFG_MD5[*]} " =~ ${CFG_MD5} ]]; then
+        KCONFIG_EXTRACTED="$LOG_PATH_MODULE/kernel_config_extracted_$(basename "$IMG_").log"
+        cp "$TMP1" "$KCONFIG_EXTRACTED"
+        KCFG_MD5+=("$CFG_MD5")
+        # return value of 4 means we are done and we are going back to the main function of this module for the next file
+        return 4
+      else
+        print_output "[*] Firmware binary $ORANGE$IMG$NC already analyzed .. skipping"
+        return 4
+      fi
+    fi
+  fi
+}
+
+try_decompress() {
+  # Source: https://raw.githubusercontent.com/torvalds/linux/master/scripts/extract-ikconfig
+  for POS in $(tr "$1\n$2" "\n$2=" < "$IMG" | grep -abo "^$2"); do
+    POS=${POS%%:*}
+    tail -c+"$POS" "$IMG" | "$3" > "$TMP2" 2> /dev/null
+    dump_config "$TMP2"
+    if [[ $? -eq 4 ]]; then
+      return 4
+    fi
+  done
+}
+
+check_kconfig() {
+  local KCONFIG_FILE="${1:-}"
+
+  if ! [[ -f "$KCONFIG_FILE" ]]; then
+    return
+  fi
+
+  if [[ "$KCONF_HARD_CHECKER" != "NA" ]]; then
+    print_output "[*] Testing kernel configuration file $ORANGE$KCONFIG_FILE$NC with kconfig-hardened-check"
+    local KCONF_LOG=""
+    KCONF_LOG="$LOG_PATH_MODULE/kconfig_hardening_check_$(basename "$KCONFIG_FILE").log"
+    "$KCONF_HARD_CHECKER" -c "$KCONFIG_FILE" | tee -a "$KCONF_LOG"
+    if [[ -f "$KCONF_LOG" ]]; then
+      FAILED_KSETTINGS=$(grep -c "FAIL: " "$KCONF_LOG")
+      if [[ "$FAILED_KSETTINGS" -gt 0 ]]; then
+        print_output "[+] Found $ORANGE$FAILED_KSETTINGS$GREEN security related kernel settings which should be reviewed - $ORANGE$(print_path "$KCONFIG_FILE")$NC" "" "$KCONF_LOG"
+        print_ln
+        write_log "[*] Statistics:$FAILED_KSETTINGS"
+      fi
+    fi
+  fi
 }

--- a/modules/S24_kernel_bin_identifier.sh
+++ b/modules/S24_kernel_bin_identifier.sh
@@ -29,12 +29,6 @@ S24_kernel_bin_identifier()
   local CFG_MD5=""
   export KCFG_MD5=()
 
-  if [[ -e "$EXT_DIR"/kconfig-hardened-check/bin/kconfig-hardened-check ]]; then
-    KCONF_HARD_CHECKER="$EXT_DIR/kconfig-hardened-check/bin/kconfig-hardened-check"
-  else
-    KCONF_HARD_CHECKER="NA"
-  fi
-
   readarray -t FILE_ARR_TMP < <(find "$FIRMWARE_PATH_CP" -xdev "${EXCL_FIND[@]}" -type f ! \( -iname "*.udeb" -o -iname "*.deb" \
     -o -iname "*.ipk" -o -iname "*.pdf" -o -iname "*.php" -o -iname "*.txt" -o -iname "*.doc" -o -iname "*.rtf" -o -iname "*.docx" \
     -o -iname "*.htm" -o -iname "*.html" -o -iname "*.md5" -o -iname "*.sha1" -o -iname "*.torrent" \) \
@@ -239,22 +233,27 @@ try_decompress() {
 check_kconfig() {
   local KCONFIG_FILE="${1:-}"
 
+  if [[ -e "$EXT_DIR"/kconfig-hardened-check/bin/kconfig-hardened-check ]]; then
+    KCONF_HARD_CHECKER="$EXT_DIR/kconfig-hardened-check/bin/kconfig-hardened-check"
+  else
+    print_output "[-] Kernel config hardening checker not found"
+    return
+  fi
+
   if ! [[ -f "$KCONFIG_FILE" ]]; then
     return
   fi
 
-  if [[ "$KCONF_HARD_CHECKER" != "NA" ]]; then
-    print_output "[*] Testing kernel configuration file $ORANGE$KCONFIG_FILE$NC with kconfig-hardened-check"
-    local KCONF_LOG=""
-    KCONF_LOG="$LOG_PATH_MODULE/kconfig_hardening_check_$(basename "$KCONFIG_FILE").log"
-    "$KCONF_HARD_CHECKER" -c "$KCONFIG_FILE" | tee -a "$KCONF_LOG"
-    if [[ -f "$KCONF_LOG" ]]; then
-      FAILED_KSETTINGS=$(grep -c "FAIL: " "$KCONF_LOG")
-      if [[ "$FAILED_KSETTINGS" -gt 0 ]]; then
-        print_output "[+] Found $ORANGE$FAILED_KSETTINGS$GREEN security related kernel settings which should be reviewed - $ORANGE$(print_path "$KCONFIG_FILE")$NC" "" "$KCONF_LOG"
-        print_ln
-        write_log "[*] Statistics:$FAILED_KSETTINGS"
-      fi
+  print_output "[*] Testing kernel configuration file $ORANGE$KCONFIG_FILE$NC with kconfig-hardened-check"
+  local KCONF_LOG=""
+  KCONF_LOG="$LOG_PATH_MODULE/kconfig_hardening_check_$(basename "$KCONFIG_FILE").log"
+  "$KCONF_HARD_CHECKER" -c "$KCONFIG_FILE" | tee -a "$KCONF_LOG"
+  if [[ -f "$KCONF_LOG" ]]; then
+    FAILED_KSETTINGS=$(grep -c "FAIL: " "$KCONF_LOG")
+    if [[ "$FAILED_KSETTINGS" -gt 0 ]]; then
+      print_output "[+] Found $ORANGE$FAILED_KSETTINGS$GREEN security related kernel settings which should be reviewed - $ORANGE$(print_path "$KCONFIG_FILE")$NC" "" "$KCONF_LOG"
+      print_ln
+      write_log "[*] Statistics:$FAILED_KSETTINGS"
     fi
   fi
 }

--- a/modules/S25_kernel_check.sh
+++ b/modules/S25_kernel_check.sh
@@ -75,13 +75,6 @@ S25_kernel_check()
       FOUND=1
     fi
 
-  elif [[ $KERNEL -eq 1 ]] && [[ $FIRMWARE -eq 0 ]]  ; then
-    print_output "[*] Check kernel configuration ""$(print_path "$KERNEL_CONFIG" )"" via checksec.sh"
-    print_output "$("$EXT_DIR""/checksec" --kernel="$KERNEL_CONFIG")"
-    FOUND=1
-    export LOG_PATH_MODULE
-    LOG_PATH_MODULE="$LOG_DIR""/""$(echo "$MODULE_MAIN_NAME" | tr '[:upper:]' '[:lower:]')"
-
   elif [[ $KERNEL -eq 1 ]] && [[ $FIRMWARE -eq 1 ]] ; then
 
     populate_karrays

--- a/modules/S25_kernel_check.sh
+++ b/modules/S25_kernel_check.sh
@@ -21,7 +21,7 @@
 S25_kernel_check()
 {
   module_log_init "${FUNCNAME[0]}"
-  module_title "Identify and check kernel version"
+  module_title "Identify and analyze kernel version"
   pre_module_reporter "${FUNCNAME[0]}"
 
   export KERNEL_VERSION=()


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature
Small bug fixes

* **What is the current behavior?** (You can also link to an open issue here)

No extraction (and no testing) of kernel config from binary kernel

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

Extract kernel config from binary kernel with https://raw.githubusercontent.com/torvalds/linux/master/scripts/extract-ikconfig (which is integrated in s24 module)

* **Limitations:**

Kernel config checks with EMBA parameter -k is currently disabled and needs some further attention!

Testfirmware: https://github.com/OWASP/IoTGoat/releases/download/v1.0/IoTGoat-raspberry-pi2.img
Start EMBA the following way: `sudo ./emba.sh -f ~/Downloads/IoTGoat-raspberry-pi2.img -l ~/emba_logs_IoTGoat -S -p ./scan-profiles/default-scan.emba -m s24`

![image](https://user-images.githubusercontent.com/497520/197547044-ddd9c69d-b529-4a2f-b102-9884599e1f78.png)

![image](https://user-images.githubusercontent.com/497520/197547112-c91ff2fd-e8cc-4ce8-9b07-efedbdea4c3a.png)

![image](https://user-images.githubusercontent.com/497520/197547180-40cbbdcc-1ac2-4daf-8b42-b2a53cbc3b51.png)
