### PR TITLE
Better UEFI extractor

### DIFF
--- a/helpers/helpers_emba_dependency_check.sh
+++ b/helpers/helpers_emba_dependency_check.sh
@@ -383,7 +383,10 @@ dependency_check()
 
     check_dep_tool "ubireader image extractor" "ubireader_extract_images"
     check_dep_tool "ubireader file extractor" "ubireader_extract_files"
-
+    
+    # UEFI
+    check_dep_tool "UEFI image extractor" "$EXT_DIR""/UEFITool/UEFIExtract"
+    
     if function_exists F20_vul_aggregator; then
       # CVE-search
       # TODO change to portcheck and write one for external hosts

--- a/installer.sh
+++ b/installer.sh
@@ -230,6 +230,8 @@ if [[ "$CVE_SEARCH" -ne 1 ]] || [[ "$DOCKER_SETUP" -ne 1 ]] || [[ "$IN_DOCKER" -
 
   IP18_qnap_decryptor
 
+  IP35_uefi_extraction
+
   IP61_unblob
 
   IP99_binwalk_default

--- a/installer/IP35_uefi_extraction.sh
+++ b/installer/IP35_uefi_extraction.sh
@@ -24,7 +24,7 @@ IP35_uefi_extraction() {
   print_file_info "UEFIExtract_NE_A62_linux_x86_64.zip" "Release-version A62" "https://github.com/LongSoft/UEFITool/releases/download/A62/UEFIExtract_NE_A62_linux_x86_64.zip" "external/UEFITool/UEFIExtract_NE_A62_linux_x86_64.zip"
   print_tool_info "unzip" 1
 
-  if [[ "$LIST_DEP" -eq 1 ]]; then
+  if [[ "$LIST_DEP" -eq 1 ]] || [[ $DOCKER_SETUP -eq 0 ]]; then
       ANSWER=("n")
   else
       echo -e "\\n""$MAGENTA""$BOLD""UEFI Extraction Tool"" will be downloaded (if not already on the system) installed!""$NC"

--- a/installer/IP35_uefi_extraction.sh
+++ b/installer/IP35_uefi_extraction.sh
@@ -24,7 +24,7 @@ IP35_uefi_extraction() {
   print_file_info "UEFIExtract_NE_A62_linux_x86_64.zip" "Release-version A62" "https://github.com/LongSoft/UEFITool/releases/download/A62/UEFIExtract_NE_A62_linux_x86_64.zip" "external/UEFITool/UEFIExtract_NE_A62_linux_x86_64.zip"
   print_tool_info "unzip" 1
 
-  if [[ "$LIST_DEP" -eq 1 ]] || [[ $DOCKER_SETUP -eq 0 ]]; then
+  if [[ "$LIST_DEP" -eq 1 ]] || [[ $DOCKER_SETUP -eq 1 ]]; then
       ANSWER=("n")
   else
       echo -e "\\n""$MAGENTA""$BOLD""UEFI Extraction Tool"" will be downloaded (if not already on the system) installed!""$NC"
@@ -32,10 +32,10 @@ IP35_uefi_extraction() {
   fi
 
   case ${ANSWER:0:1} in
-      y|Y )
+    y|Y )
       apt-get install "${INSTALL_APP_LIST[@]}" -y --no-install-recommends
       if ! [[ -d external/UEFITool ]]; then
-          mkdir external/UEFITool
+        mkdir external/UEFITool
       fi
       download_file "UEFIExtract_NE_A62_linux_x86_64.zip" "https://github.com/LongSoft/UEFITool/releases/download/A62/UEFIExtract_NE_A62_linux_x86_64.zip" "external/UEFITool/UEFIExtract_NE_A62_linux_x86_64.zip"
       if [[ -f "external/UEFITool/UEFIExtract_NE_A62_linux_x86_64.zip" ]]; then
@@ -43,7 +43,7 @@ IP35_uefi_extraction() {
           unzip external/UEFITool/UEFIExtract_NE_A62_linux_x86_64.zip -d external/UEFITool
         fi
       else
-          echo -e "$ORANGE""UEFITool installation failed - check it manually""$NC"
+        echo -e "$ORANGE""UEFITool installation failed - check it manually""$NC"
       fi
       ;;
   esac

--- a/installer/IP35_uefi_extraction.sh
+++ b/installer/IP35_uefi_extraction.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# EMBA - EMBEDDED LINUX ANALYZER
+#
+# Copyright 2020-2022 Siemens Energy AG
+#
+# EMBA comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
+# welcome to redistribute it under the terms of the GNU General Public License.
+# See LICENSE file for usage of this software.
+#
+# EMBA is licensed under GPLv3
+#
+# Author(s): Benedikt Kuehne
+
+# Description:  Installs UEFIExtract from https://github.com/LongSoft/UEFITool/releases
+#               into external/UEFITool/UEFIExtract
+
+IP35_uefi_extraction() {
+  module_title "${FUNCNAME[0]}"
+  
+  
+  INSTALL_APP_LIST=()
+
+  print_file_info "UEFIExtract_NE_A62_linux_x86_64.zip" "Release-version A62" "https://github.com/LongSoft/UEFITool/releases/download/A62/UEFIExtract_NE_A62_linux_x86_64.zip" "external/UEFITool/UEFIExtract_NE_A62_linux_x86_64.zip"
+  print_tool_info "unzip" 1
+
+  if [[ "$LIST_DEP" -eq 1 ]]; then
+      ANSWER=("n")
+  else
+      echo -e "\\n""$MAGENTA""$BOLD""UEFI Extraction Tool"" will be downloaded (if not already on the system) installed!""$NC"
+      ANSWER=("y")
+  fi
+
+  case ${ANSWER:0:1} in
+      y|Y )
+      apt-get install "${INSTALL_APP_LIST[@]}" -y --no-install-recommends
+      if ! [[ -d external/UEFITool ]]; then
+          mkdir external/UEFITool
+      fi
+      download_file "UEFIExtract_NE_A62_linux_x86_64.zip" "https://github.com/LongSoft/UEFITool/releases/download/A62/UEFIExtract_NE_A62_linux_x86_64.zip" "external/UEFITool/UEFIExtract_NE_A62_linux_x86_64.zip"
+      if [[ -f "external/UEFITool/UEFIExtract_NE_A62_linux_x86_64.zip" ]]; then
+          unzip external/UEFITool/UEFIExtract_NE_A62_linux_x86_64.zip -d external/UEFITool
+      else
+          echo -e "$ORANGE""UEFITool installation failed - check it manually""$NC"
+      fi
+      ;;
+  esac
+}

--- a/installer/IP35_uefi_extraction.sh
+++ b/installer/IP35_uefi_extraction.sh
@@ -39,7 +39,9 @@ IP35_uefi_extraction() {
       fi
       download_file "UEFIExtract_NE_A62_linux_x86_64.zip" "https://github.com/LongSoft/UEFITool/releases/download/A62/UEFIExtract_NE_A62_linux_x86_64.zip" "external/UEFITool/UEFIExtract_NE_A62_linux_x86_64.zip"
       if [[ -f "external/UEFITool/UEFIExtract_NE_A62_linux_x86_64.zip" ]]; then
+        if ! [[ -f external/UEFITool/UEFIExtract ]]; then
           unzip external/UEFITool/UEFIExtract_NE_A62_linux_x86_64.zip -d external/UEFITool
+        fi
       else
           echo -e "$ORANGE""UEFITool installation failed - check it manually""$NC"
       fi

--- a/modules/F50_base_aggregator.sh
+++ b/modules/F50_base_aggregator.sh
@@ -23,6 +23,7 @@ F50_base_aggregator() {
   CVE_AGGREGATOR_LOG="f20_vul_aggregator.txt"
   F20_EXPLOITS_LOG="$LOG_DIR"/f20_vul_aggregator/exploits-overview.txt
   P02_LOG="p02_firmware_bin_file_check.csv"
+  P35_LOG="p35_uefi_extractor.txt"
   S03_LOG="s03_firmware_bin_base_analyzer.txt"
   S05_LOG="s05_firmware_details.txt"
   S06_LOG="s06_distribution_identification.txt"
@@ -118,6 +119,11 @@ output_overview() {
       write_link "p99"
       write_csv_log "architecture_verified" "unknown" "NA"
       write_csv_log "architecture_unverified" "$PRE_ARCH" "NA"
+    fi
+    if [[ -n "$EFI_ARCH" ]]; then
+      print_output "[+] Detected architecture:""$ORANGE"" ""$EFI_ARCH""$NC"
+      write_link "p99"
+      write_csv_log "architecture_verified" "$EFI_ARCH" "NA"
     fi
   else
     write_csv_log "architecture_verified" "unknown" "NA"
@@ -684,6 +690,7 @@ get_data() {
   export KNOWN_EXPLOITED_COUNTER=0
   export ENTROPY=""
   export PRE_ARCH=""
+  export EFI_ARCH=""
   export FILE_ARR_COUNT=0
   export DETECTED_DIR=0
   export LINUX_DISTRIS=()
@@ -730,6 +737,11 @@ get_data() {
 
   if [[ -f "$LOG_DIR"/"$P02_LOG" ]]; then
     ENTROPY=$(grep -a "Entropy" "$LOG_DIR"/"$P02_LOG" | cut -d\; -f2 | cut -d= -f2 | sed 's/^\ //' || true)
+  fi
+  if [[ -f "$LOG_DIR"/"$P35_LOG" ]]; then
+    EFI_ARCH=$(grep -a "Possible architecture details found" "$LOG_DIR"/"$P35_LOG" | cut -d: -f2 | sed 's/\ //g' | tr '\n' '/' || true)
+    EFI_ARCH="${EFI_ARCH%\/}"
+    EFI_ARCH=$(strip_color_codes "$EFI_ARCH")
   fi
   if [[ -f "$LOG_DIR"/"$S02_LOG" ]]; then
     FWHUNTER_CNT=$(grep -a "\[\*\]\ Statistics:" "$LOG_DIR"/"$S02_LOG" | cut -d: -f2 || true)

--- a/modules/P35_UEFI_extractor.sh
+++ b/modules/P35_UEFI_extractor.sh
@@ -123,6 +123,7 @@ uefi_extractor(){
 
   NVARS=$(grep -c "NVAR entry" "$UEFI_EXTRACT_REPORT_FILE")
   PE32_IMAGE=$(grep -c "PE32 image" "$UEFI_EXTRACT_REPORT_FILE")
+  DRIVER_COUNT=$(grep -c "DXE driver" "$UEFI_EXTRACT_REPORT_FILE")
   EFI_ARCH=$(find "$EXTRACTION_DIR_" -name 'info.txt' -exec grep 'Machine type:' {} \; | sed -E 's/Machine\ type\:\ //g' | uniq | head -n 1)
 
   if [[ -n "$EFI_ARCH" ]]; then

--- a/modules/P35_UEFI_extractor.sh
+++ b/modules/P35_UEFI_extractor.sh
@@ -118,8 +118,8 @@ uefi_extractor(){
   fi
 
   print_ln
-  print_output "[*] Using the following firmware directory ($ORANGE$EXTRACTION_DIR_/firmware.dump$NC) as base directory:"
-  find "$EXTRACTION_DIR_"/firmware.dump -xdev -maxdepth 1 -ls | tee -a "$LOG_FILE"
+  print_output "[*] Using the following firmware directory ($ORANGE${EXTRACTION_DIR_}firmware.dump$NC) as base directory:"
+  find "$EXTRACTION_DIR_"firmware.dump -xdev -maxdepth 1 -ls | tee -a "$LOG_FILE"
   print_ln
 
   NVARS=$(grep -c "NVAR entry" "$UEFI_EXTRACT_REPORT_FILE")

--- a/modules/P35_UEFI_extractor.sh
+++ b/modules/P35_UEFI_extractor.sh
@@ -100,6 +100,9 @@ uefi_extractor(){
   fi
 
   FIRMWARE_NAME_="$(basename "$FIRMWARE_PATH_")"
+  if [[ -d "$EXTRACTION_DIR_" ]]; then
+    mkdir -p "$EXTRACTION_DIR_"
+  fi
   cp "$FIRMWARE_PATH_" "$EXTRACTION_DIR_"
   $UEFI_EXTRACT_BIN "$EXTRACTION_DIR_"/firmware all &> "$LOG_PATH_MODULE"/uefi_extractor_"$FIRMWARE_NAME_".log
   UEFI_EXTRACT_REPORT_FILE="$EXTRACTION_DIR_"/firmware.report.txt

--- a/modules/P35_UEFI_extractor.sh
+++ b/modules/P35_UEFI_extractor.sh
@@ -28,11 +28,11 @@ P35_UEFI_extractor() {
 
     EXTRACTION_DIR="$LOG_DIR"/firmware/uefi_extraction/
 
-    if [[ "$UEFI_AMI_CAPSULE" -gt 0 ]]; then
-      ami_extractor "$FIRMWARE_PATH" "$EXTRACTION_DIR"
-    else
-      uefi_extractor "$FIRMWARE_PATH" "$EXTRACTION_DIR"
-    fi
+    # if [[ "$UEFI_AMI_CAPSULE" -gt 0 ]]; then
+    #   ami_extractor "$FIRMWARE_PATH" "$EXTRACTION_DIR"
+    # else
+    uefi_extractor "$FIRMWARE_PATH" "$EXTRACTION_DIR"
+    # fi
 
     if [[ "$FILES_UEFI" -gt 0 ]]; then
       MD5_DONE_DEEP+=( "$(md5sum "$FIRMWARE_PATH" | awk '{print $1}')" )

--- a/modules/P35_UEFI_extractor.sh
+++ b/modules/P35_UEFI_extractor.sh
@@ -92,7 +92,7 @@ uefi_extractor(){
   local DIRS_UEFI=0
   local NVARS=0
   local PE32_IMAGE=0
-  local ARCHITECTURE=""
+  local EFI_ARCH=""
 
   if ! [[ -f "$FIRMWARE_PATH_" ]]; then
     print_output "[-] No file for extraction provided"
@@ -121,9 +121,9 @@ uefi_extractor(){
   PE32_IMAGE=$(grep -c "PE32 image" "$UEFI_EXTRACT_REPORT_FILE")
   EFI_ARCH=$(find "$EXTRACTION_DIR_" -name 'info.txt' -exec grep 'Machine type:' {} \; | sed -E 's/Machine\ type\:\ //g' | uniq )
 
-  if ! [[ -z "$EFI_ARCH" ]]; then
+  if [[ -n "$EFI_ARCH" ]]; then
     print_output "[*] Found $ORANGE$PE32_IMAGE$NC PE32 images for architecture $ORANGE$EFI_ARCH$ORANGE drivers."
-    print_output "[+] Possible architecture details found ($ORANGE UEFI Extractor $NC): $ORANGE$EFI_ARCH_$NC"
+    print_output "[+] Possible architecture details found ($ORANGE UEFI Extractor $NC): $ORANGE$EFI_ARCH$NC"
     export EFI_ARCH
     backup_var "EFI_ARCH" "$EFI_ARCH"
   fi

--- a/modules/P35_UEFI_extractor.sh
+++ b/modules/P35_UEFI_extractor.sh
@@ -44,39 +44,40 @@ P35_UEFI_extractor() {
   fi
 }
 
-ami_extractor() {
-  sub_module_title "AMI capsule extractor"
-
-  local FIRMWARE_PATH_="${1:-}"
-  local EXTRACTION_DIR_="${2:-}"
-  local DIRS_UEFI=0
-  local FIRMWARE_NAME_=""
-
-  if ! [[ -f "$FIRMWARE_PATH_" ]]; then
-    print_output "[-] No file for extraction provided"
-    return
-  fi
-
-  FIRMWARE_NAME_="$(basename "$FIRMWARE_PATH_")"
-
-  echo -ne '\n' | python3 "$EXT_DIR"/BIOSUtilities/AMI_PFAT_Extract.py -o "$EXTRACTION_DIR_" "$FIRMWARE_PATH_" &> "$LOG_PATH_MODULE"/uefi_ami_"$FIRMWARE_NAME_".log
-
-  if [[ -f "$LOG_PATH_MODULE"/uefi_ami_"$FIRMWARE_NAME_".log ]]; then
-    tee -a "$LOG_FILE" < "$LOG_PATH_MODULE"/uefi_ami_"$FIRMWARE_NAME_".log
-  fi
-
-  print_ln
-  print_output "[*] Using the following firmware directory ($ORANGE$EXTRACTION_DIR_$NC) as base directory:"
-  find "$EXTRACTION_DIR_" -xdev -maxdepth 1 -ls | tee -a "$LOG_FILE"
-  print_ln
-
-  FILES_UEFI=$(find "$EXTRACTION_DIR_" -type f | wc -l)
-  DIRS_UEFI=$(find "$EXTRACTION_DIR_" -type d | wc -l)
-  print_output "[*] Extracted $ORANGE$FILES_UEFI$NC files and $ORANGE$DIRS_UEFI$NC directories from the firmware image."
-  write_csv_log "Extractor module" "Original file" "extracted file/dir" "file counter" "directory counter" "further details"
-  write_csv_log "UEFI AMI extractor" "$FIRMWARE_PATH_" "$EXTRACTION_DIR_" "$FILES_UEFI" "$DIRS_UEFI" "NA"
-  print_ln
-}
+# TODO marked for deletion
+# ami_extractor() {
+#   sub_module_title "AMI capsule extractor"
+# 
+#   local FIRMWARE_PATH_="${1:-}"
+#   local EXTRACTION_DIR_="${2:-}"
+#   local DIRS_UEFI=0
+#   local FIRMWARE_NAME_=""
+# 
+#   if ! [[ -f "$FIRMWARE_PATH_" ]]; then
+#     print_output "[-] No file for extraction provided"
+#     return
+#   fi
+# 
+#   FIRMWARE_NAME_="$(basename "$FIRMWARE_PATH_")"
+# 
+#   echo -ne '\n' | python3 "$EXT_DIR"/BIOSUtilities/AMI_PFAT_Extract.py -o "$EXTRACTION_DIR_" "$FIRMWARE_PATH_" &> "$LOG_PATH_MODULE"/uefi_ami_"$FIRMWARE_NAME_".log
+# 
+#   if [[ -f "$LOG_PATH_MODULE"/uefi_ami_"$FIRMWARE_NAME_".log ]]; then
+#     tee -a "$LOG_FILE" < "$LOG_PATH_MODULE"/uefi_ami_"$FIRMWARE_NAME_".log
+#   fi
+# 
+#   print_ln
+#   print_output "[*] Using the following firmware directory ($ORANGE$EXTRACTION_DIR_$NC) as base directory:"
+#   find "$EXTRACTION_DIR_" -xdev -maxdepth 1 -ls | tee -a "$LOG_FILE"
+#   print_ln
+# 
+#   FILES_UEFI=$(find "$EXTRACTION_DIR_" -type f | wc -l)
+#   DIRS_UEFI=$(find "$EXTRACTION_DIR_" -type d | wc -l)
+#   print_output "[*] Extracted $ORANGE$FILES_UEFI$NC files and $ORANGE$DIRS_UEFI$NC directories from the firmware image."
+#   write_csv_log "Extractor module" "Original file" "extracted file/dir" "file counter" "directory counter" "further details"
+#   write_csv_log "UEFI AMI extractor" "$FIRMWARE_PATH_" "$EXTRACTION_DIR_" "$FILES_UEFI" "$DIRS_UEFI" "NA"
+#   print_ln
+# }
 
 uefi_extractor(){
   sub_module_title "UEFI Extractor"

--- a/modules/P35_UEFI_extractor.sh
+++ b/modules/P35_UEFI_extractor.sh
@@ -100,12 +100,12 @@ uefi_extractor(){
   fi
 
   FIRMWARE_NAME_="$(basename "$FIRMWARE_PATH_")"
-  if [[ -d "$EXTRACTION_DIR_" ]]; then
+  if ! [[ -d "$EXTRACTION_DIR_" ]]; then
     mkdir -p "$EXTRACTION_DIR_"
   fi
   cp "$FIRMWARE_PATH_" "$EXTRACTION_DIR_"
-  $UEFI_EXTRACT_BIN "$EXTRACTION_DIR_"/firmware all &> "$LOG_PATH_MODULE"/uefi_extractor_"$FIRMWARE_NAME_".log
-  UEFI_EXTRACT_REPORT_FILE="$EXTRACTION_DIR_"/firmware.report.txt
+  $UEFI_EXTRACT_BIN "$EXTRACTION_DIR_"firmware all &> "$LOG_PATH_MODULE"/uefi_extractor_"$FIRMWARE_NAME_".log
+  UEFI_EXTRACT_REPORT_FILE="$EXTRACTION_DIR_"firmware.report.txt
   mv "$UEFI_EXTRACT_REPORT_FILE" "$LOG_PATH_MODULE"
   UEFI_EXTRACT_REPORT_FILE="$LOG_PATH_MODULE"/firmware.report.txt
   if [[ -f "$EXTRACTION_DIR_"/firmware ]]; then

--- a/modules/P35_UEFI_extractor.sh
+++ b/modules/P35_UEFI_extractor.sh
@@ -30,6 +30,8 @@ P35_UEFI_extractor() {
 
     if [[ "$UEFI_AMI_CAPSULE" -gt 0 ]]; then
       ami_extractor "$FIRMWARE_PATH" "$EXTRACTION_DIR"
+    else
+      uefi_extractor "$FIRMWARE_PATH" "$EXTRACTION_DIR"
     fi
 
     if [[ "$FILES_UEFI" -gt 0 ]]; then
@@ -73,5 +75,64 @@ ami_extractor() {
   print_output "[*] Extracted $ORANGE$FILES_UEFI$NC files and $ORANGE$DIRS_UEFI$NC directories from the firmware image."
   write_csv_log "Extractor module" "Original file" "extracted file/dir" "file counter" "directory counter" "further details"
   write_csv_log "UEFI AMI extractor" "$FIRMWARE_PATH_" "$EXTRACTION_DIR_" "$FILES_UEFI" "$DIRS_UEFI" "NA"
+  print_ln
+}
+
+uefi_extractor(){
+  sub_module_title "UEFI Extractor"
+
+  local FIRMWARE_PATH_="${1:-}"
+  local EXTRACTION_DIR_="${2:-}"
+
+  local FIRMWARE_NAME_=""
+  local UEFI_EXTRACT_REPORT_FILE=""
+
+  local UEFI_EXTRACT_BIN="$EXT_DIR""/UEFITool/UEFIExtract"
+  local FILES_UEFI=0
+  local DIRS_UEFI=0
+  local NVARS=0
+  local PE32_IMAGE=0
+  local ARCHITECTURE=""
+
+  if ! [[ -f "$FIRMWARE_PATH_" ]]; then
+    print_output "[-] No file for extraction provided"
+    return
+  fi
+
+  FIRMWARE_NAME_="$(basename "$FIRMWARE_PATH_")"
+
+  # UEFIExtract uses abs_path of file to determine target-dir(auto generated)
+  $UEFI_EXTRACT_BIN "$FIRMWARE_PATH_" all &> "$LOG_PATH_MODULE"/uefi_extractor_"$FIRMWARE_NAME_".log
+  mv "$FIRMWARE_PATH_"".dump" "$EXTRACTION_DIR_"
+  mv "$FIRMWARE_PATH_"".report.txt" "$LOG_PATH_MODULE"
+  
+  UEFI_EXTRACT_REPORT_FILE="$LOG_PATH_MODULE"/"$FIRMWARE_NAME_".report.txt
+
+  if [[ -f "$LOG_PATH_MODULE"/uefi_extractor_"$FIRMWARE_NAME_".log ]]; then
+    tee -a "$LOG_FILE" < "$LOG_PATH_MODULE"/uefi_extractor_"$FIRMWARE_NAME_".log
+  fi
+
+  print_ln
+  print_output "[*] Using the following firmware directory ($ORANGE$EXTRACTION_DIR_$NC) as base directory:"
+  find "$EXTRACTION_DIR_" -xdev -maxdepth 1 -ls | tee -a "$LOG_FILE"
+  print_ln
+
+  NVARS=$(grep -c "NVAR entry" "$UEFI_EXTRACT_REPORT_FILE")
+  PE32_IMAGE=$(grep -c "PE32 image" "$UEFI_EXTRACT_REPORT_FILE")
+  EFI_ARCH=$(find "$EXTRACTION_DIR_" -name 'info.txt' -exec grep 'Machine type:' {} \; | sed -E 's/Machine\ type\:\ //g' | uniq )
+
+  if ! [[ -z "$EFI_ARCH" ]]; then
+    print_output "[*] Found $ORANGE$PE32_IMAGE$NC PE32 images for architecture $ORANGE$EFI_ARCH$ORANGE drivers."
+    print_output "[+] Possible architecture details found ($ORANGE UEFI Extractor $NC): $ORANGE$EFI_ARCH_$NC"
+    export EFI_ARCH
+    backup_var "EFI_ARCH" "$EFI_ARCH"
+  fi
+
+  FILES_UEFI=$(grep -c "File" "$UEFI_EXTRACT_REPORT_FILE")
+  DIRS_UEFI=$(find "$EXTRACTION_DIR_" -type d | wc -l)
+  print_output "[*] Extracted $ORANGE$FILES_UEFI$NC files and $ORANGE$DIRS_UEFI$NC directories from the firmware image."
+  print_output "[*] Found $ORANGE$NVARS$NC NVARS and $ORANGE$DRIVER_COUNT$ORANGE drivers."
+  write_csv_log "Extractor module" "Original file" "extracted file/dir" "file counter" "directory counter" "further details"
+  write_csv_log "UEFI extractor" "$FIRMWARE_PATH_" "$EXTRACTION_DIR_" "$FILES_UEFI" "$DIRS_UEFI" "NA"
   print_ln
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add a more general extraction tool for UEFI images
+ meta-data extraction from UEFI



**What is the current behavior?** (You can also link to an open issue here)
1. either EFI images get extracted via last-resort (binwalk)
2. or AMI-extractor works



**What is the new behavior (if this is a feature change)? If possible add a screenshot.**
UEFI images get extracted with [UEFITool](https://github.com/LongSoft/UEFITool)



**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
❗  **Requires new EMBA container**