### PR TITLE
New Kernels for system emulation, qcow extractor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,6 @@ RUN yes | sudo /installer.sh -D && \
 
 WORKDIR /emba
 
+# nosemgrep
 ENTRYPOINT [ "/bin/bash" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /
 # updates system
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get -y install wget kmod procps sudo dialog apt-utils curl git
+    apt-get -y install wget kmod procps sudo dialog apt curl git
 
 # install EMBA, disable coredumps and final cleanup
 RUN yes | sudo /installer.sh -D && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
         - /dev:/dev
         - /lib/modules:/lib/modules:ro
         - /boot:/boot:ro
-        - /home/m1k3/github-repos/EMBA-emulation-binaries:/external/EMBA_Live_bins/:ro
+          # - /home/m1k3/github-repos/EMBA-emulation-binaries:/external/EMBA_Live_bins/:ro
     environment:
         - USER
     devices:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
         - /dev:/dev
         - /lib/modules:/lib/modules:ro
         - /boot:/boot:ro
-          # - /home/m1k3/github-repos/EMBA-emulation-binaries:/external/EMBA_Live_bins/:ro
+        - /home/m1k3/github-repos/EMBA-emulation-binaries:/external/EMBA_Live_bins/:ro
     environment:
         - USER
     devices:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
         - /dev:/dev
         - /lib/modules:/lib/modules:ro
         - /boot:/boot:ro
-          #- /home/m1k3/github-repos/EMBA-emulation-binaries:/external/EMBA_Live_bins/:ro
+        - /home/m1k3/github-repos/EMBA-emulation-binaries:/external/EMBA_Live_bins/:ro
     environment:
         - USER
     devices:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,11 @@
 version: "3"
 services:
+  # nosemgrep
   emba:
     image: embeddedanalyzer/emba:latest
     read_only: true
     # all pre-checker mount modules need privileged mode
+    # nosemgrep
     privileged: true
     # /root/.config is needed for binwalk - further recovery for other tools needed
     # /root/.cache is needed for unblob -> further recovery of this directory needed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
         - /dev:/dev
         - /lib/modules:/lib/modules:ro
         - /boot:/boot:ro
-          #- /home/m1k3/github-repos/EMBA-emulation-binaries:/external/firmae/binaries/:ro
+          #- /home/m1k3/github-repos/EMBA-emulation-binaries:/external/EMBA_Live_bins/:ro
     environment:
         - USER
     devices:
@@ -53,15 +53,6 @@ services:
       core:
         hard: 0
         soft: 0
-    # adjust the following limits to protect your host
-    #deploy:
-    #  resources:
-    #    limits:
-    #      memory: 12G
-    #      cpus: 7
-    #    reservations:
-    #      cpus: 2
-    #      memory: 4G
 
 networks:
   emba_runs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
         - /dev:/dev
         - /lib/modules:/lib/modules:ro
         - /boot:/boot:ro
-        - /home/m1k3/github-repos/EMBA-emulation-binaries:/external/EMBA_Live_bins/:ro
+          # - /home/m1k3/github-repos/EMBA-emulation-binaries:/external/EMBA_Live_bins/:ro
     environment:
         - USER
     devices:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
       - /root/.cache/pypoetry/virtualenvs:exec
       - /root
       - /root/.cargo/bin:exec
-      - /run
+      - /run/lock
+      - /var
       - /var/run
       - /var/tmp
       - /external/freetz-ng/.fakeroot-cache

--- a/emba.sh
+++ b/emba.sh
@@ -589,6 +589,9 @@ main()
   fi
 
 
+  # Check all dependencies of EMBA
+  dependency_check
+
   if [[ "$ONLY_DEP" -eq 0 ]]; then
     if [[ "$UPDATE" -eq 1 ]]; then
       write_notification "EMBA starts with update"
@@ -624,9 +627,6 @@ main()
         exit 1
       fi
     fi
-
-    # Check all dependencies of EMBA
-    dependency_check
 
     if [[ "$ONLY_DEP" -eq 0 ]]; then
       # check provided paths for validity

--- a/emba.sh
+++ b/emba.sh
@@ -588,8 +588,6 @@ main()
     export PATH_CVE_SEARCH="$EXT_DIR""/cve-search/bin/search.py"
   fi
 
-  # Check all dependencies of EMBA
-  dependency_check
 
   if [[ "$ONLY_DEP" -eq 0 ]]; then
     if [[ "$UPDATE" -eq 1 ]]; then
@@ -626,6 +624,9 @@ main()
         exit 1
       fi
     fi
+
+    # Check all dependencies of EMBA
+    dependency_check
 
     if [[ "$ONLY_DEP" -eq 0 ]]; then
       # check provided paths for validity
@@ -893,7 +894,7 @@ main()
         fi
         exit 0
       else
-        print_output "[-] EMBA failed in docker mode!" "main"
+        print_output "[-] EMBA failed in docker mode!" "no_log"
         cleaner 0
         write_notification "EMBA failed analysis in default mode"
         exit 1

--- a/emba.sh
+++ b/emba.sh
@@ -316,8 +316,8 @@ main()
 
   export EMBA_PID="$$"
   # if this is a release version set RELEASE to 1, add a banner to config/banner and name the banner with the version details
-  export RELEASE=1
-  export EMBA_VERSION="1.1.3"
+  export RELEASE=0
+  export EMBA_VERSION="1.2.0"
   export STRICT_MODE=0
   export UPDATE=0
   export ARCH_CHECK=1

--- a/emba.sh
+++ b/emba.sh
@@ -588,7 +588,6 @@ main()
     export PATH_CVE_SEARCH="$EXT_DIR""/cve-search/bin/search.py"
   fi
 
-
   # Check all dependencies of EMBA
   dependency_check
 

--- a/helpers/base.html
+++ b/helpers/base.html
@@ -32,7 +32,7 @@ Contributor(s): Michael Messner, Stefan Haboeck
     <a class="inherit" href="./index.html"><img class="inherit" id="logoImage" src="./style/emba.svg" alt="logo"></a>
   </div>
   <div id="nav">
-      <a id="embark" class="hidden" href="{{ embarkBackUrl }}">&laquo; Back to EMBArk</a>
+      <a id="embark" class="hidden" href="{{ embarkBackUrl }}">&laquo; Back to EMBArk</a> <!-- nosem -->
       <a class="backButton" href="./index.html">&laquo; Back to main</a>
       <!-- navigation start -->
       <!-- navigation end -->

--- a/helpers/helpers_emba_dependency_check.sh
+++ b/helpers/helpers_emba_dependency_check.sh
@@ -497,7 +497,7 @@ dependency_check()
     # Full system emulation modules (L*)
     if [[ $FULL_EMULATION -eq 1 ]]; then
       check_dep_tool "Qemu system emulator ARM" "qemu-system-arm"
-      #check_dep_tool "Qemu system emulator ARM64" "qemu-system-aarch64"
+      check_dep_tool "Qemu system emulator ARM64" "qemu-system-aarch64"
       check_dep_tool "Qemu system emulator MIPS" "qemu-system-mips"
       check_dep_tool "Qemu system emulator MIPSel" "qemu-system-mipsel"
       check_dep_tool "Qemu system emulator MIPS64" "qemu-system-mips64"
@@ -589,6 +589,8 @@ architecture_dep_check() {
     ARCH_STR="mips64n32"
   elif [[ "$ARCH" == "ARM" ]] ; then
     ARCH_STR="arm"
+  elif [[ "$ARCH" == "ARM64" ]] ; then
+    ARCH_STR="aarch64"
   elif [[ "$ARCH" == "x86" ]] ; then
     ARCH_STR="i386"
   elif [[ "$ARCH" == "x64" ]] ; then

--- a/helpers/helpers_emba_dependency_check.sh
+++ b/helpers/helpers_emba_dependency_check.sh
@@ -504,8 +504,8 @@ dependency_check()
       check_dep_tool "Metasploit framework" "msfconsole"
       # This port is used by our Qemu installation and should not be used by another process.
       # This check is not a blocker for the test. It is checked again by the emulation module:
-      check_emulation_port "Running Qemu service" "2001"
-      check_emulation_port "Running Qemu service" "4321"
+      check_emulation_port "Running Qemu network service" "2001"
+      check_emulation_port "Running Qemu network service" "4321"
     fi
 
     if [[ "$CWE_CHECKER" -eq 1 ]]; then

--- a/helpers/helpers_emba_dependency_check.sh
+++ b/helpers/helpers_emba_dependency_check.sh
@@ -472,13 +472,18 @@ dependency_check()
       check_dep_tool "Qemu system emulator ARM" "qemu-system-arm"
       check_dep_tool "Qemu system emulator MIPS" "qemu-system-mips"
       check_dep_tool "Qemu system emulator MIPSel" "qemu-system-mipsel"
+      check_dep_tool "Qemu system emulator MIPS64" "qemu-system-mips64"
+      check_dep_tool "Qemu system emulator MIPS64el" "qemu-system-mips64el"
+      check_dep_tool "Qemu system emulator NIOS2" "qemu-system-nios2"
+      check_dep_tool "Qemu system emulator x86" "qemu-system-x86_64"
 
       # check only some of the needed files
-      check_dep_file "console.*" "$EXT_DIR""/firmae/binaries/console.mipsel"
-      check_dep_file "busybox.*" "$EXT_DIR""/firmae/binaries/busybox.mipsel"
-      check_dep_file "libnvram.*" "$EXT_DIR""/firmae/binaries/libnvram.so.armel"
-      check_dep_file "vmlinux.mips*" "$EXT_DIR""/firmae/binaries/vmlinux.mipseb.4"
-      check_dep_file "zImage.armel" "$EXT_DIR""/firmae/binaries/zImage.armel"
+      check_dep_file "console.*" "$EXT_DIR""/EMBA_Live_bins/console.x86el"
+      check_dep_file "busybox.*" "$EXT_DIR""/EMBA_Live_bins/busybox.mipsel"
+      check_dep_file "libnvram.*" "$EXT_DIR""/EMBA_Live_bins/libnvram.so.armel"
+      check_dep_file "libnvram_ioctl.*" "$EXT_DIR""/EMBA_Live_bins/libnvram_ioctl.so.mipsel"
+      check_dep_file "vmlinux.mips*" "$EXT_DIR""/EMBA_Live_bins/vmlinux.mips64r2el.4"
+      check_dep_file "zImage.armel" "$EXT_DIR""/EMBA_Live_bins/zImage.armel"
 
       check_dep_file "fixImage.sh" "$MOD_DIR""/L10_system_emulation/fixImage.sh"
       check_dep_file "preInit.sh" "$MOD_DIR""/L10_system_emulation/preInit.sh"
@@ -500,6 +505,7 @@ dependency_check()
       # This port is used by our Qemu installation and should not be used by another process.
       # This check is not a blocker for the test. It is checked again by the emulation module:
       check_emulation_port "Running Qemu service" "2001"
+      check_emulation_port "Running Qemu service" "4321"
     fi
 
     if [[ "$CWE_CHECKER" -eq 1 ]]; then
@@ -518,8 +524,12 @@ dependency_check()
 
   if [[ $DEP_ERROR -gt 0 ]] || [[ $DEP_EXIT -gt 0 ]]; then
     print_output "\\n""$ORANGE""Some dependencies are missing - please check your installation\\n" "no_log"
-    print_output "$ORANGE""To install all needed dependencies, run '""$NC""sudo ./installer.sh""$ORANGE""'." "no_log"
-    print_output "$ORANGE""Learn more about the installation on the EMBA wiki: ""$NC""https://github.com/e-m-b-a/emba/wiki/installation\\n" "no_log"
+    if [[ "$IN_DOCKER" -eq 1 ]]; then
+      print_output "$ORANGE""Looks like your docker container is outdated - please update your base image: ""$NC""sudo docker pull embeddedanalyzer/emba""$ORANGE""'." "no_log"
+    else
+      print_output "$ORANGE""To install all needed dependencies, run '""$NC""sudo ./installer.sh""$ORANGE""'." "no_log"
+      print_output "$ORANGE""Learn more about the installation on the EMBA wiki: ""$NC""https://github.com/e-m-b-a/emba/wiki/installation\\n" "no_log"
+    fi
 
     if [[ $ONLY_DEP -eq 1 ]] || [[ $FORCE -eq 0 ]] || [[ $DEP_EXIT -gt 0 ]]; then
       exit 1

--- a/helpers/helpers_emba_dependency_check.sh
+++ b/helpers/helpers_emba_dependency_check.sh
@@ -504,6 +504,8 @@ dependency_check()
       check_dep_tool "Qemu system emulator MIPS64el" "qemu-system-mips64el"
       check_dep_tool "Qemu system emulator NIOS2" "qemu-system-nios2"
       check_dep_tool "Qemu system emulator x86" "qemu-system-x86_64"
+      # check_dep_tool "Qemu system emulator RISC-V" "qemu-system-riscv32"
+      # check_dep_tool "Qemu system emulator RISC-V64" "qemu-system-riscv64"
 
       # check only some of the needed files
       check_dep_file "console.*" "$EXT_DIR""/EMBA_Live_bins/console.x86el"
@@ -587,6 +589,8 @@ architecture_dep_check() {
     ARCH_STR="mips64_III"
   elif [[ "$ARCH" == "MIPS64N32" ]] ; then
     ARCH_STR="mips64n32"
+  elif [[ "$ARCH" == "MIPS64v1" ]] ; then
+    ARCH_STR="mips64v1"
   elif [[ "$ARCH" == "ARM" ]] ; then
     ARCH_STR="arm"
   elif [[ "$ARCH" == "ARM64" ]] ; then
@@ -599,8 +603,12 @@ architecture_dep_check() {
   elif [[ "$ARCH" == "PPC" ]] ; then
     #ARCH_STR="powerpc:common"
     ARCH_STR="powerpc"
+  elif [[ "$ARCH" == "PPC64" ]] ; then
+    ARCH_STR="powerpc64"
   elif [[ "$ARCH" == "NIOS2" ]] ; then
     ARCH_STR="nios2"
+  elif [[ "$ARCH" == "RISCV" ]] ; then
+    ARCH_STR="riscv"
   else
     ARCH_STR="unknown"
   fi

--- a/helpers/helpers_emba_dependency_check.sh
+++ b/helpers/helpers_emba_dependency_check.sh
@@ -511,7 +511,7 @@ dependency_check()
       check_dep_file "console.*" "$EXT_DIR""/EMBA_Live_bins/console.x86el"
       check_dep_file "busybox.*" "$EXT_DIR""/EMBA_Live_bins/busybox.mipsel"
       check_dep_file "libnvram.*" "$EXT_DIR""/EMBA_Live_bins/libnvram.so.armel"
-      check_dep_file "libnvram_ioctl.*" "$EXT_DIR""/EMBA_Live_bins/libnvram_ioctl.so.mipsel"
+      check_dep_file "libnvram_ioctl.*" "$EXT_DIR""/EMBA_Live_bins/libnvram_ioctl.so.mips64v1el"
       check_dep_file "vmlinux.mips*" "$EXT_DIR""/EMBA_Live_bins/vmlinux.mips64r2el.4"
       check_dep_file "zImage.armel" "$EXT_DIR""/EMBA_Live_bins/zImage.armel"
 

--- a/helpers/helpers_emba_dependency_check.sh
+++ b/helpers/helpers_emba_dependency_check.sh
@@ -181,6 +181,31 @@ check_emulation_port() {
   fi
 }
 
+setup_unblob() {
+  TOOL_NAME="${1:-}"
+
+  print_output "    ""$TOOL_NAME"" - \\c" "no_log"
+
+  if command -v unblob; then
+    echo -e "$GREEN""ok""$NC"
+  elif ! command -v unblob && [[ -f "$EXT_DIR"/unblob/unblob_path.cfg ]]; then
+    # recover unblob installation - usually we are in the docker container
+    if ! [[ -d "$HOME"/.cache ]]; then
+      mkdir "$HOME"/.cache
+    fi
+    cp -pr "$EXT_DIR"/unblob/root_cache/* "$HOME"/.cache/
+    if [[ -e $(cat "$EXT_DIR"/unblob/unblob_path.cfg)/bin/"$UNBLOB_BIN" ]]; then
+      UNBLOB_PATH="$(cat "$EXT_DIR"/unblob/unblob_path.cfg)""/bin/"
+      export PATH=$PATH:"$UNBLOB_PATH"
+      echo -e "$GREEN""ok""$NC"
+    else
+      echo -e "$RED""not ok""$NC"
+    fi
+  else
+    echo -e "$RED""not ok""$NC"
+  fi
+}
+
 dependency_check() 
 {
   module_title "Dependency check" "no_log"
@@ -349,6 +374,8 @@ dependency_check()
       fi
     fi
     export MPLCONFIGDIR="$TMP_DIR"
+
+    setup_unblob "unblob"
 
     # jtr
     check_dep_tool "john"

--- a/helpers/helpers_emba_dependency_check.sh
+++ b/helpers/helpers_emba_dependency_check.sh
@@ -497,6 +497,7 @@ dependency_check()
     # Full system emulation modules (L*)
     if [[ $FULL_EMULATION -eq 1 ]]; then
       check_dep_tool "Qemu system emulator ARM" "qemu-system-arm"
+      #check_dep_tool "Qemu system emulator ARM64" "qemu-system-aarch64"
       check_dep_tool "Qemu system emulator MIPS" "qemu-system-mips"
       check_dep_tool "Qemu system emulator MIPSel" "qemu-system-mipsel"
       check_dep_tool "Qemu system emulator MIPS64" "qemu-system-mips64"
@@ -532,7 +533,8 @@ dependency_check()
       # This port is used by our Qemu installation and should not be used by another process.
       # This check is not a blocker for the test. It is checked again by the emulation module:
       check_emulation_port "Running Qemu network service" "2001"
-      check_emulation_port "Running Qemu network service" "4321"
+      # Port 4321 is used for Qemu telnet access and should be available
+      check_emulation_port "Running Qemu telnet service" "4321"
     fi
 
     if [[ "$CWE_CHECKER" -eq 1 ]]; then

--- a/helpers/helpers_emba_helpers.sh
+++ b/helpers/helpers_emba_helpers.sh
@@ -265,7 +265,7 @@ restore_permissions() {
     print_output "[*] Restoring directory permissions for user: $ORANGE$ORIG_USER$NC" "no_log"
     ORIG_UID="$(grep "UID" "$LOG_DIR"/orig_user.log | awk '{print $2}')"
     ORIG_GID="$(grep "GID" "$LOG_DIR"/orig_user.log | awk '{print $2}')"
-    chown "$ORIG_UID":"$ORIG_GID" "$LOG_DIR" -R
+    chown "$ORIG_UID":"$ORIG_GID" "$LOG_DIR" -R || true
     rm "$LOG_DIR"/orig_user.log || true
   fi
 }

--- a/helpers/helpers_emba_prepare.sh
+++ b/helpers/helpers_emba_prepare.sh
@@ -155,7 +155,7 @@ architecture_check()
 {
   if [[ $ARCH_CHECK -eq 1 ]] ; then
     print_output "[*] Architecture auto detection (could take some time)\\n"
-    local ARCH_MIPS=0 ARCH_ARM=0 ARCH_X64=0 ARCH_X86=0 ARCH_PPC=0 ARCH_NIOS2=0 ARCH_MIPS64R2=0 ARCH_MIPS64_III=0 ARCH_MIPS64_N32=0
+    local ARCH_MIPS=0 ARCH_ARM=0 ARCH_ARM64=0 ARCH_X64=0 ARCH_X86=0 ARCH_PPC=0 ARCH_NIOS2=0 ARCH_MIPS64R2=0 ARCH_MIPS64_III=0 ARCH_MIPS64_N32=0
     local D_END_LE=0 D_END_BE=0
     local D_FLAGS=""
     export ARM_HF=0
@@ -187,7 +187,11 @@ architecture_check()
         ARCH_MIPS=$((ARCH_MIPS+1))
         continue
       elif [[ "$D_ARCH" == *"ARM"* ]] ; then
-        ARCH_ARM=$((ARCH_ARM+1))
+        if [[ "$D_ARCH" == *"ARM aarch64"* ]] ; then
+          ARCH_ARM64=$((ARCH_ARM64+1))
+        else
+          ARCH_ARM=$((ARCH_ARM+1))
+        fi
         if [[ "$D_FLAGS" == *"hard-float"* ]]; then
           ARM_HF=$((ARM_HF+1))
         fi
@@ -210,44 +214,48 @@ architecture_check()
       fi
     done
 
-    if [[ $((ARCH_MIPS+ARCH_ARM+ARCH_X64+ARCH_X86+ARCH_PPC+ARCH_NIOS2+ARCH_MIPS64R2+ARCH_MIPS64_III+ARCH_MIPS64_N32)) -gt 0 ]] ; then
+    if [[ $((ARCH_MIPS+ARCH_ARM+ARCH_X64+ARCH_X86+ARCH_PPC+ARCH_NIOS2+ARCH_MIPS64R2+ARCH_MIPS64_III+ARCH_MIPS64_N32+ARCH_ARM64)) -gt 0 ]] ; then
       print_output "$(indent "$(orange "Architecture  Count")")"
       if [[ $ARCH_MIPS -gt 0 ]] ; then print_output "$(indent "$(orange "MIPS          ""$ARCH_MIPS")")" ; fi
       if [[ $ARCH_MIPS64R2 -gt 0 ]] ; then print_output "$(indent "$(orange "MIPS64r2     ""$ARCH_MIPS64R2")")" ; fi
       if [[ $ARCH_MIPS64_III -gt 0 ]] ; then print_output "$(indent "$(orange "MIPS64 III     ""$ARCH_MIPS64_III")")" ; fi
       if [[ $ARCH_MIPS64_N32 -gt 0 ]] ; then print_output "$(indent "$(orange "MIPS64 N32     ""$ARCH_MIPS64_N32")")" ; fi
       if [[ $ARCH_ARM -gt 0 ]] ; then print_output "$(indent "$(orange "ARM           ""$ARCH_ARM")")" ; fi
+      if [[ $ARCH_ARM64 -gt 0 ]] ; then print_output "$(indent "$(orange "ARM64         ""$ARCH_ARM64")")" ; fi
       if [[ $ARCH_X64 -gt 0 ]] ; then print_output "$(indent "$(orange "x64           ""$ARCH_X64")")" ; fi
       if [[ $ARCH_X86 -gt 0 ]] ; then print_output "$(indent "$(orange "x86           ""$ARCH_X86")")" ; fi
       if [[ $ARCH_PPC -gt 0 ]] ; then print_output "$(indent "$(orange "PPC           ""$ARCH_PPC")")" ; fi
       if [[ $ARCH_NIOS2 -gt 0 ]] ; then print_output "$(indent "$(orange "NIOS II       ""$ARCH_NIOS2")")" ; fi
 
       if [[ $ARCH_MIPS -gt $ARCH_ARM ]] && [[ $ARCH_MIPS -gt $ARCH_X64 ]] && [[ $ARCH_MIPS -gt $ARCH_X86 ]] && [[ $ARCH_MIPS -gt $ARCH_PPC ]] && [[ $ARCH_MIPS -gt $ARCH_NIOS2 ]] && \
-        [[ $ARCH_MIPS -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_MIPS -gt $ARCH_MIPS64_III ]] && [[ $ARCH_MIPS -gt $ARCH_MIPS64_N32 ]]; then
+        [[ $ARCH_MIPS -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_MIPS -gt $ARCH_MIPS64_III ]] && [[ $ARCH_MIPS -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_MIPS -gt $ARCH_ARM64 ]]; then
         D_ARCH="MIPS"
       elif [[ $ARCH_ARM -gt $ARCH_MIPS ]] && [[ $ARCH_ARM -gt $ARCH_X64 ]] && [[ $ARCH_ARM -gt $ARCH_X86 ]] && [[ $ARCH_ARM -gt $ARCH_PPC ]] && [[ $ARCH_ARM -gt $ARCH_NIOS2 ]] && \
-        [[ $ARCH_ARM -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_ARM -gt $ARCH_MIPS64_III ]] && [[ $ARCH_ARM -gt $ARCH_MIPS64_N32 ]]; then
+        [[ $ARCH_ARM -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_ARM -gt $ARCH_MIPS64_III ]] && [[ $ARCH_ARM -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_ARM -gt $ARCH_ARM64 ]]; then
         D_ARCH="ARM"
+      elif [[ $ARCH_ARM64 -gt $ARCH_MIPS ]] && [[ $ARCH_ARM64 -gt $ARCH_X64 ]] && [[ $ARCH_ARM64 -gt $ARCH_X86 ]] && [[ $ARCH_ARM64 -gt $ARCH_PPC ]] && [[ $ARCH_ARM64 -gt $ARCH_NIOS2 ]] && \
+        [[ $ARCH_ARM64 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_ARM64 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_ARM64 -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_ARM64 -gt $ARCH_ARM ]]; then
+        D_ARCH="ARM64"
       elif [[ $ARCH_X64 -gt $ARCH_MIPS ]] && [[ $ARCH_X64 -gt $ARCH_ARM ]] && [[ $ARCH_X64 -gt $ARCH_X86 ]] && [[ $ARCH_X64 -gt $ARCH_PPC ]] && [[ $ARCH_X64 -gt $ARCH_NIOS2 ]] && \
-        [[ $ARCH_X64 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_X64 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_X64 -gt $ARCH_MIPS64_N32 ]]; then
+        [[ $ARCH_X64 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_X64 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_X64 -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_X64 -gt $ARCH_ARM64 ]]; then
         D_ARCH="x64"
       elif [[ $ARCH_X86 -gt $ARCH_MIPS ]] && [[ $ARCH_X86 -gt $ARCH_X64 ]] && [[ $ARCH_X86 -gt $ARCH_ARM ]] && [[ $ARCH_X86 -gt $ARCH_PPC ]] && [[ $ARCH_X86 -gt $ARCH_NIOS2 ]] && \
-        [[ $ARCH_X86 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_X86 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_X86 -gt $ARCH_MIPS64_N32 ]]; then
+        [[ $ARCH_X86 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_X86 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_X86 -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_X86 -gt $ARCH_ARM64 ]]; then
         D_ARCH="x86"
       elif [[ $ARCH_PPC -gt $ARCH_MIPS ]] && [[ $ARCH_PPC -gt $ARCH_ARM ]] && [[ $ARCH_PPC -gt $ARCH_X64 ]] && [[ $ARCH_PPC -gt $ARCH_X86 ]] && [[ $ARCH_PPC -gt $ARCH_NIOS2 ]] && \
-        [[ $ARCH_PPC -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_PPC -gt $ARCH_MIPS64_III ]] && [[ $ARCH_PPC -gt $ARCH_MIPS64_N32 ]]; then
+        [[ $ARCH_PPC -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_PPC -gt $ARCH_MIPS64_III ]] && [[ $ARCH_PPC -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_PPC -gt $ARCH_ARM64 ]]; then
         D_ARCH="PPC"
       elif [[ $ARCH_NIOS2 -gt $ARCH_MIPS ]] && [[ $ARCH_NIOS2 -gt $ARCH_ARM ]] && [[ $ARCH_NIOS2 -gt $ARCH_X64 ]] && [[ $ARCH_NIOS2 -gt $ARCH_X86 ]] && [[ $ARCH_NIOS2 -gt $ARCH_PPC ]] \
-        && [[ $ARCH_NIOS2 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_NIOS2 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_NIOS2 -gt $ARCH_MIPS64_N32 ]]; then
+        && [[ $ARCH_NIOS2 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_NIOS2 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_NIOS2 -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_NIOS2 -gt $ARCH_ARM64 ]]; then
         D_ARCH="NIOS2"
       elif [[ $ARCH_MIPS64R2 -gt $ARCH_MIPS ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_ARM ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_X64 ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_X86 ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_PPC ]] && \
-        [[ $ARCH_MIPS64R2 -gt $ARCH_NIOS2 ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_MIPS64_N32 ]]; then
+        [[ $ARCH_MIPS64R2 -gt $ARCH_NIOS2 ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_ARM64 ]]; then
         D_ARCH="MIPS64R2"
       elif [[ $ARCH_MIPS64_III -gt $ARCH_MIPS ]] && [[ $ARCH_MIPS64_III -gt $ARCH_ARM ]] && [[ $ARCH_MIPS64_III -gt $ARCH_X64 ]] && [[ $ARCH_MIPS64_III -gt $ARCH_X86 ]] && [[ $ARCH_MIPS64_III -gt $ARCH_PPC ]] && \
-        [[ $ARCH_MIPS64_III -gt $ARCH_NIOS2 ]] && [[ $ARCH_MIPS64_III -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_MIPS64_III -gt $ARCH_MIPS64_N32 ]]; then
+        [[ $ARCH_MIPS64_III -gt $ARCH_NIOS2 ]] && [[ $ARCH_MIPS64_III -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_MIPS64_III -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_MIPS64_III -gt $ARCH_ARM64 ]]; then
         D_ARCH="MIPS64_3"
       elif [[ $ARCH_MIPS64_N32 -gt $ARCH_MIPS ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_ARM ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_X64 ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_X86 ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_PPC ]] && \
-        [[ $ARCH_MIPS64_N32 -gt $ARCH_NIOS2 ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_ARM ]]; then
+        [[ $ARCH_MIPS64_N32 -gt $ARCH_NIOS2 ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_ARM ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_ARM64 ]]; then
         D_ARCH="MIPS64N32"
       else
         D_ARCH="unknown"
@@ -413,7 +421,7 @@ check_firmware()
 detect_root_dir_helper() {
   SEARCH_PATH="${1:-}"
 
-  print_output "[*] Root directory auto detection (could take some time)\\n"
+  print_output "[*] Root directory auto detection for $ORANGE$SEARCH_PATH$NC (could take some time)\\n"
   ROOT_PATH=()
   export ROOT_PATH
   local R_PATH
@@ -430,8 +438,10 @@ detect_root_dir_helper() {
       for R_PATH in "${INTERPRETER_FULL_RPATH[@]}"; do
         # remove the interpreter path from the full path:
         R_PATH="${R_PATH//$INTERPRETER_ESCAPED/}"
-        ROOT_PATH+=( "$R_PATH" )
-        MECHANISM="binary interpreter"
+        if [[ -v R_PATH ]] && [[ -d "$R_PATH" ]]; then
+          ROOT_PATH+=( "$R_PATH" )
+          MECHANISM="binary interpreter"
+        fi
       done
     done
   fi

--- a/helpers/helpers_emba_prepare.sh
+++ b/helpers/helpers_emba_prepare.sh
@@ -155,7 +155,8 @@ architecture_check()
 {
   if [[ $ARCH_CHECK -eq 1 ]] ; then
     print_output "[*] Architecture auto detection (could take some time)\\n"
-    local ARCH_MIPS=0 ARCH_ARM=0 ARCH_ARM64=0 ARCH_X64=0 ARCH_X86=0 ARCH_PPC=0 ARCH_NIOS2=0 ARCH_MIPS64R2=0 ARCH_MIPS64_III=0 ARCH_MIPS64_N32=0
+    local ARCH_MIPS=0 ARCH_ARM=0 ARCH_ARM64=0 ARCH_X64=0 ARCH_X86=0 ARCH_PPC=0 ARCH_NIOS2=0 ARCH_MIPS64R2=0 ARCH_MIPS64_III=0
+    local ARCH_MIPS64v1=0 ARCH_MIPS64_N32=0 ARCH_RISCV=0 ARCH_PPC64=0
     local D_END_LE=0 D_END_BE=0
     local D_FLAGS=""
     export ARM_HF=0
@@ -183,6 +184,9 @@ architecture_check()
       elif [[ "$D_ARCH" == *"64-bit"*"MIPS-III"* ]] ; then
         ARCH_MIPS64_III=$((ARCH_MIPS64_III+1))
         continue
+      elif [[ "$D_ARCH" == *"64-bit"*"MIPS64 version 1"* ]] ; then
+        ARCH_MIPS64v1=$((ARCH_MIPS64v1+1))
+        continue
       elif [[ "$D_ARCH" == *"MIPS"* ]] ; then
         ARCH_MIPS=$((ARCH_MIPS+1))
         continue
@@ -205,58 +209,89 @@ architecture_check()
       elif [[ "$D_ARCH" == *"80386"* ]] ; then
         ARCH_X86=$((ARCH_X86+1))
         continue
+      elif [[ "$D_ARCH" == *"64-bit PowerPC"* ]] ; then
+        ARCH_PPC64=$((ARCH_PPC64+1))
+        continue
       elif [[ "$D_ARCH" == *"PowerPC"* ]] ; then
         ARCH_PPC=$((ARCH_PPC+1))
         continue
       elif [[ "$D_ARCH" == *"Altera Nios II"* ]] ; then
         ARCH_NIOS2=$((ARCH_NIOS2+1))
         continue
+      elif [[ "$D_ARCH" == *"UCB RISC-V"* ]] ; then
+        ARCH_RISCV=$((ARCH_RISCV+1))
+        continue
       fi
     done
 
-    if [[ $((ARCH_MIPS+ARCH_ARM+ARCH_X64+ARCH_X86+ARCH_PPC+ARCH_NIOS2+ARCH_MIPS64R2+ARCH_MIPS64_III+ARCH_MIPS64_N32+ARCH_ARM64)) -gt 0 ]] ; then
+    if [[ $((ARCH_MIPS+ARCH_ARM+ARCH_X64+ARCH_X86+ARCH_PPC+ARCH_NIOS2+ARCH_MIPS64R2+ARCH_MIPS64_III+ARCH_MIPS64_N32+ARCH_ARM64+ARCH_MIPS64v1+ARCH_RISCV+ARCH_PPC64)) -gt 0 ]] ; then
       print_output "$(indent "$(orange "Architecture  Count")")"
       if [[ $ARCH_MIPS -gt 0 ]] ; then print_output "$(indent "$(orange "MIPS          ""$ARCH_MIPS")")" ; fi
       if [[ $ARCH_MIPS64R2 -gt 0 ]] ; then print_output "$(indent "$(orange "MIPS64r2     ""$ARCH_MIPS64R2")")" ; fi
       if [[ $ARCH_MIPS64_III -gt 0 ]] ; then print_output "$(indent "$(orange "MIPS64 III     ""$ARCH_MIPS64_III")")" ; fi
       if [[ $ARCH_MIPS64_N32 -gt 0 ]] ; then print_output "$(indent "$(orange "MIPS64 N32     ""$ARCH_MIPS64_N32")")" ; fi
+      if [[ $ARCH_MIPS64v1 -gt 0 ]] ; then print_output "$(indent "$(orange "MIPS64v1      ""$ARCH_MIPS64v1")")" ; fi
       if [[ $ARCH_ARM -gt 0 ]] ; then print_output "$(indent "$(orange "ARM           ""$ARCH_ARM")")" ; fi
       if [[ $ARCH_ARM64 -gt 0 ]] ; then print_output "$(indent "$(orange "ARM64         ""$ARCH_ARM64")")" ; fi
       if [[ $ARCH_X64 -gt 0 ]] ; then print_output "$(indent "$(orange "x64           ""$ARCH_X64")")" ; fi
       if [[ $ARCH_X86 -gt 0 ]] ; then print_output "$(indent "$(orange "x86           ""$ARCH_X86")")" ; fi
       if [[ $ARCH_PPC -gt 0 ]] ; then print_output "$(indent "$(orange "PPC           ""$ARCH_PPC")")" ; fi
+      if [[ $ARCH_PPC -gt 0 ]] ; then print_output "$(indent "$(orange "PPC64         ""$ARCH_PPC64")")" ; fi
       if [[ $ARCH_NIOS2 -gt 0 ]] ; then print_output "$(indent "$(orange "NIOS II       ""$ARCH_NIOS2")")" ; fi
+      if [[ $ARCH_RISCV -gt 0 ]] ; then print_output "$(indent "$(orange "RISC-V        ""$ARCH_RISCV")")" ; fi
 
       if [[ $ARCH_MIPS -gt $ARCH_ARM ]] && [[ $ARCH_MIPS -gt $ARCH_X64 ]] && [[ $ARCH_MIPS -gt $ARCH_X86 ]] && [[ $ARCH_MIPS -gt $ARCH_PPC ]] && [[ $ARCH_MIPS -gt $ARCH_NIOS2 ]] && \
-        [[ $ARCH_MIPS -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_MIPS -gt $ARCH_MIPS64_III ]] && [[ $ARCH_MIPS -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_MIPS -gt $ARCH_ARM64 ]]; then
+        [[ $ARCH_MIPS -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_MIPS -gt $ARCH_MIPS64_III ]] && [[ $ARCH_MIPS -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_MIPS -gt $ARCH_ARM64 ]] && \
+        [[ $ARCH_MIPS -gt $ARCH_RISCV ]] && [[ $ARCH_MIPS -gt $ARCH_MIPS64v1 ]] && [[ $ARCH_MIPS -gt $ARCH_PPC64 ]]; then
         D_ARCH="MIPS"
       elif [[ $ARCH_ARM -gt $ARCH_MIPS ]] && [[ $ARCH_ARM -gt $ARCH_X64 ]] && [[ $ARCH_ARM -gt $ARCH_X86 ]] && [[ $ARCH_ARM -gt $ARCH_PPC ]] && [[ $ARCH_ARM -gt $ARCH_NIOS2 ]] && \
-        [[ $ARCH_ARM -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_ARM -gt $ARCH_MIPS64_III ]] && [[ $ARCH_ARM -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_ARM -gt $ARCH_ARM64 ]]; then
+        [[ $ARCH_ARM -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_ARM -gt $ARCH_MIPS64_III ]] && [[ $ARCH_ARM -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_ARM -gt $ARCH_ARM64 ]] && \
+        [[ $ARCH_ARM -gt $ARCH_RISCV ]] && [[ $ARCH_ARM -gt $ARCH_MIPS64v1 ]] && [[ $ARCH_ARM -gt $ARCH_PPC64 ]]; then
         D_ARCH="ARM"
       elif [[ $ARCH_ARM64 -gt $ARCH_MIPS ]] && [[ $ARCH_ARM64 -gt $ARCH_X64 ]] && [[ $ARCH_ARM64 -gt $ARCH_X86 ]] && [[ $ARCH_ARM64 -gt $ARCH_PPC ]] && [[ $ARCH_ARM64 -gt $ARCH_NIOS2 ]] && \
-        [[ $ARCH_ARM64 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_ARM64 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_ARM64 -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_ARM64 -gt $ARCH_ARM ]]; then
+        [[ $ARCH_ARM64 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_ARM64 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_ARM64 -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_ARM64 -gt $ARCH_ARM ]] && \
+        [[ $ARCH_ARM64 -gt $ARCH_RISCV ]] && [[ $ARCH_ARM64 -gt $ARCH_MIPS64v1 ]] && [[ $ARCH_ARM64 -gt $ARCH_PPC64 ]]; then
         D_ARCH="ARM64"
       elif [[ $ARCH_X64 -gt $ARCH_MIPS ]] && [[ $ARCH_X64 -gt $ARCH_ARM ]] && [[ $ARCH_X64 -gt $ARCH_X86 ]] && [[ $ARCH_X64 -gt $ARCH_PPC ]] && [[ $ARCH_X64 -gt $ARCH_NIOS2 ]] && \
-        [[ $ARCH_X64 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_X64 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_X64 -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_X64 -gt $ARCH_ARM64 ]]; then
+        [[ $ARCH_X64 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_X64 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_X64 -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_X64 -gt $ARCH_ARM64 ]] && \
+        [[ $ARCH_X64 -gt $ARCH_RISCV ]] && [[ $ARCH_X64 -gt $ARCH_MIPS64v1 ]] && [[ $ARCH_X64 -gt $ARCH_PPC64 ]]; then
         D_ARCH="x64"
       elif [[ $ARCH_X86 -gt $ARCH_MIPS ]] && [[ $ARCH_X86 -gt $ARCH_X64 ]] && [[ $ARCH_X86 -gt $ARCH_ARM ]] && [[ $ARCH_X86 -gt $ARCH_PPC ]] && [[ $ARCH_X86 -gt $ARCH_NIOS2 ]] && \
-        [[ $ARCH_X86 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_X86 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_X86 -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_X86 -gt $ARCH_ARM64 ]]; then
+        [[ $ARCH_X86 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_X86 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_X86 -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_X86 -gt $ARCH_ARM64 ]] && \
+        [[ $ARCH_X86 -gt $ARCH_RISCV ]] && [[ $ARCH_X86 -gt $ARCH_MIPS64v1 ]] && [[ $ARCH_X86 -gt $ARCH_PPC64 ]]; then
         D_ARCH="x86"
       elif [[ $ARCH_PPC -gt $ARCH_MIPS ]] && [[ $ARCH_PPC -gt $ARCH_ARM ]] && [[ $ARCH_PPC -gt $ARCH_X64 ]] && [[ $ARCH_PPC -gt $ARCH_X86 ]] && [[ $ARCH_PPC -gt $ARCH_NIOS2 ]] && \
-        [[ $ARCH_PPC -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_PPC -gt $ARCH_MIPS64_III ]] && [[ $ARCH_PPC -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_PPC -gt $ARCH_ARM64 ]]; then
+        [[ $ARCH_PPC -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_PPC -gt $ARCH_MIPS64_III ]] && [[ $ARCH_PPC -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_PPC -gt $ARCH_ARM64 ]] && \
+        [[ $ARCH_PPC -gt $ARCH_RISCV ]] && [[ $ARCH_PPC -gt $ARCH_MIPS64v1 ]] && [[ $ARCH_PPC -gt $ARCH_PPC64 ]]; then
         D_ARCH="PPC"
-      elif [[ $ARCH_NIOS2 -gt $ARCH_MIPS ]] && [[ $ARCH_NIOS2 -gt $ARCH_ARM ]] && [[ $ARCH_NIOS2 -gt $ARCH_X64 ]] && [[ $ARCH_NIOS2 -gt $ARCH_X86 ]] && [[ $ARCH_NIOS2 -gt $ARCH_PPC ]] \
-        && [[ $ARCH_NIOS2 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_NIOS2 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_NIOS2 -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_NIOS2 -gt $ARCH_ARM64 ]]; then
+      elif [[ $ARCH_NIOS2 -gt $ARCH_MIPS ]] && [[ $ARCH_NIOS2 -gt $ARCH_ARM ]] && [[ $ARCH_NIOS2 -gt $ARCH_X64 ]] && [[ $ARCH_NIOS2 -gt $ARCH_X86 ]] && [[ $ARCH_NIOS2 -gt $ARCH_PPC ]] && \
+        [[ $ARCH_NIOS2 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_NIOS2 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_NIOS2 -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_NIOS2 -gt $ARCH_ARM64 ]] && \
+        [[ $ARCH_NIOS2 -gt $ARCH_RISCV ]] && [[ $ARCH_NIOS2 -gt $ARCH_MIPS64v1 ]] && [[ $ARCH_NIOS2 -gt $ARCH_PPC64 ]]; then
         D_ARCH="NIOS2"
       elif [[ $ARCH_MIPS64R2 -gt $ARCH_MIPS ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_ARM ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_X64 ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_X86 ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_PPC ]] && \
-        [[ $ARCH_MIPS64R2 -gt $ARCH_NIOS2 ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_ARM64 ]]; then
+        [[ $ARCH_MIPS64R2 -gt $ARCH_NIOS2 ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_MIPS64_III ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_ARM64 ]] && \
+        [[ $ARCH_MIPS64R2 -gt $ARCH_RISCV ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_MIPS64v1 ]] && [[ $ARCH_MIPS64R2 -gt $ARCH_PPC64 ]]; then
         D_ARCH="MIPS64R2"
       elif [[ $ARCH_MIPS64_III -gt $ARCH_MIPS ]] && [[ $ARCH_MIPS64_III -gt $ARCH_ARM ]] && [[ $ARCH_MIPS64_III -gt $ARCH_X64 ]] && [[ $ARCH_MIPS64_III -gt $ARCH_X86 ]] && [[ $ARCH_MIPS64_III -gt $ARCH_PPC ]] && \
-        [[ $ARCH_MIPS64_III -gt $ARCH_NIOS2 ]] && [[ $ARCH_MIPS64_III -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_MIPS64_III -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_MIPS64_III -gt $ARCH_ARM64 ]]; then
+        [[ $ARCH_MIPS64_III -gt $ARCH_NIOS2 ]] && [[ $ARCH_MIPS64_III -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_MIPS64_III -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_MIPS64_III -gt $ARCH_ARM64 ]] && \
+        [[ $ARCH_MIPS64_III -gt $ARCH_RISCV ]] && [[ $ARCH_MIPS64_III -gt $ARCH_MIPS64v1 ]] && [[ $ARCH_MIPS64_III -gt $ARCH_PPC64 ]]; then
         D_ARCH="MIPS64_3"
       elif [[ $ARCH_MIPS64_N32 -gt $ARCH_MIPS ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_ARM ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_X64 ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_X86 ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_PPC ]] && \
-        [[ $ARCH_MIPS64_N32 -gt $ARCH_NIOS2 ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_ARM ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_ARM64 ]]; then
+        [[ $ARCH_MIPS64_N32 -gt $ARCH_NIOS2 ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_ARM ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_ARM64 ]] && \
+        [[ $ARCH_MIPS64_N32 -gt $ARCH_RISCV ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_MIPS64v1 ]] && [[ $ARCH_MIPS64_N32 -gt $ARCH_PPC64 ]]; then
         D_ARCH="MIPS64N32"
+      elif [[ $ARCH_MIPS64v1 -gt $ARCH_MIPS ]] && [[ $ARCH_MIPS64v1 -gt $ARCH_ARM ]] && [[ $ARCH_MIPS64v1 -gt $ARCH_X64 ]] && [[ $ARCH_MIPS64v1 -gt $ARCH_X86 ]] && [[ $ARCH_MIPS64v1 -gt $ARCH_PPC ]] && \
+        [[ $ARCH_MIPS64v1 -gt $ARCH_NIOS2 ]] && [[ $ARCH_MIPS64v1 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_MIPS64v1 -gt $ARCH_ARM ]] && [[ $ARCH_MIPS64v1 -gt $ARCH_ARM64 ]] && \
+        [[ $ARCH_MIPS64v1 -gt $ARCH_RISCV ]] && [[ $ARCH_MIPS64v1 -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_MIPS64v1 -gt $ARCH_PPC64 ]]; then
+        D_ARCH="MIPS64v1"
+      elif [[ $ARCH_RISCV -gt $ARCH_MIPS ]] && [[ $ARCH_RISCV -gt $ARCH_ARM ]] && [[ $ARCH_RISCV -gt $ARCH_X64 ]] && [[ $ARCH_RISCV -gt $ARCH_X86 ]] && [[ $ARCH_RISCV -gt $ARCH_PPC ]] && \
+        [[ $ARCH_RISCV -gt $ARCH_NIOS2 ]] && [[ $ARCH_RISCV -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_RISCV -gt $ARCH_ARM ]] && [[ $ARCH_RISCV -gt $ARCH_ARM64 ]] && \
+        [[ $ARCH_RISCV -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_RISCV -gt $ARCH_MIPS64v1 ]] && [[ $ARCH_RISCV -gt $ARCH_PPC64 ]]; then
+        D_ARCH="RISCV"
+      elif [[ $ARCH_PPC64 -gt $ARCH_MIPS ]] && [[ $ARCH_PPC64 -gt $ARCH_ARM ]] && [[ $ARCH_PPC64 -gt $ARCH_X64 ]] && [[ $ARCH_PPC64 -gt $ARCH_X86 ]] && [[ $ARCH_PPC64 -gt $ARCH_PPC ]] && \
+        [[ $ARCH_PPC64 -gt $ARCH_NIOS2 ]] && [[ $ARCH_PPC64 -gt $ARCH_MIPS64R2 ]] && [[ $ARCH_PPC64 -gt $ARCH_ARM ]] && [[ $ARCH_PPC64 -gt $ARCH_ARM64 ]] && \
+        [[ $ARCH_PPC64 -gt $ARCH_MIPS64_N32 ]] && [[ $ARCH_PPC64 -gt $ARCH_MIPS64v1 ]] && [[ $ARCH_PPC64 -gt $ARCH_RISCV ]]; then
+        D_ARCH="PPC64"
       else
         D_ARCH="unknown"
       fi

--- a/installer.sh
+++ b/installer.sh
@@ -186,14 +186,16 @@ fi
 
 # quick check if we have enough disk space for the docker image
 
-FREE_SPACE=$(df --output=avail /var/lib/docker/ | awk 'NR==2')
-if [[ "$FREE_SPACE" -lt 13000000 ]]; then
-  echo -e "\\n""$ORANGE""EMBA installation in default mode needs a minimum of 13Gig for the docker image""$NC"
-  echo -e "\\n""$ORANGE""Please free enough space on /var/lib/docker""$NC"
-  echo ""
-  df -h
-  echo ""
-  read -p "If you know what you are doing you can press any key to continue ..." -n1 -s -r
+if [[ "$IN_DOCKER" -eq 0 ]]; then
+  FREE_SPACE=$(df --output=avail /var/lib/docker/ | awk 'NR==2')
+  if [[ "$FREE_SPACE" -lt 13000000 ]]; then
+    echo -e "\\n""$ORANGE""EMBA installation in default mode needs a minimum of 13Gig for the docker image""$NC"
+    echo -e "\\n""$ORANGE""Please free enough space on /var/lib/docker""$NC"
+    echo ""
+    df -h
+    echo ""
+    read -p "If you know what you are doing you can press any key to continue ..." -n1 -s -r
+  fi
 fi
 
 if [[ $LIST_DEP -eq 0 ]] ; then
@@ -249,6 +251,9 @@ if [[ "$CVE_SEARCH" -ne 1 ]] || [[ "$DOCKER_SETUP" -ne 1 ]] || [[ "$IN_DOCKER" -
   IP12_avm_freetz_ng_extract
 
   IP18_qnap_decryptor
+
+  # temp
+  IP35_uefi_extraction
 
   IP61_unblob
 

--- a/installer/I02_UEFI_fwhunt.sh
+++ b/installer/I02_UEFI_fwhunt.sh
@@ -21,11 +21,13 @@ I02_UEFI_fwhunt() {
 
   if [[ "$LIST_DEP" -eq 1 ]] || [[ $IN_DOCKER -eq 1 ]] || [[ $DOCKER_SETUP -eq 0 ]] || [[ $FULL -eq 1 ]]; then
 
+    print_tool_info "meson" 1
+    print_tool_info "python3-pip" 1
+    print_tool_info "gcc" 1
     print_pip_info "rzpipe"
     print_pip_info "uefi_firmware"
     print_pip_info "pyyaml"
     print_pip_info "click"
-    print_tool_info "meson" 1
     print_git_info "rizin" "rizinorg/rizin" ""
     print_git_info "fwhunt-scan" "EMBA-support-repos/fwhunt-scan" "Tools for analyzing UEFI firmware and checking UEFI modules with FwHunt rules."
     print_git_info "fwhunt-rules" "EMBA-support-repos/FwHunt" "The Binarly Firmware Hunt (FwHunt) rule format was designed to scan for known vulnerabilities in UEFI firmware."
@@ -74,8 +76,10 @@ I02_UEFI_fwhunt() {
         cd external/fwhunt-scan || ( echo "Could not install EMBA component fwhunt-scan" && exit 1 )
         git clone https://github.com/EMBA-support-repos/FwHunt.git rules
         echo "Installed $(find rules/ -iname "BRLY-*" | wc -l) fwhunt rules"
-        ldconfig
-        python3 setup.py install
+        #ldconfig
+        #export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib64/
+        #python3 setup.py install
+        pip3 install fwhunt-scan
         cd "$HOME_PATH" || ( echo "Could not install EMBA component fwhunt-scan" && exit 1 )
       ;;
     esac

--- a/installer/IL10_system_emulator.sh
+++ b/installer/IL10_system_emulator.sh
@@ -111,8 +111,8 @@ IL10_system_emulator() {
     print_file_info "zImage.armelhf" "zImage armelhf" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/zImage.armelhf" "external/EMBA_Live_bins/zImage.armelhf"print_file_info "vmlinux.mips64n32eb" "vmlinux mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64n32eb.4" "external/EMBA_Live_bins/vmlinux.mips64n32eb.4"
     print_file_info "vmlinux.mips64r2eb" "vmlinux mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64r2eb.4" "external/EMBA_Live_bins/vmlinux.mips64r2eb.4"
     print_file_info "vmlinux.mips64r2el" "vmlinux mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64r2el.4" "external/EMBA_Live_bins/vmlinux.mips64r2el.4"
-    print_file_info "vmlinux.mips64v1el" "vmlinux mips64v1el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64v1el.4" "external/EMBA_Live_bins/vmlinux.mips64v1el.4"
-    print_file_info "vmlinux.mips64v1eb" "vmlinux mips64v1eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64v1eb.4" "external/EMBA_Live_bins/vmlinux.mips64v1eb.4"
+    print_file_info "vmlinux.mips64v1el" "vmlinux mips64v1el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64v1el" "external/EMBA_Live_bins/vmlinux.mips64v1el.4"
+    print_file_info "vmlinux.mips64v1eb" "vmlinux mips64v1eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64v1eb" "external/EMBA_Live_bins/vmlinux.mips64v1eb.4"
     print_file_info "vmlinux.mipseb" "vmlinux mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mipseb.4" "external/EMBA_Live_bins/vmlinux.mipseb.4"
     print_file_info "vmlinux.mipsel" "vmlinux mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mipsel.4" "external/EMBA_Live_bins/vmlinux.mipsel.4"
     print_file_info "vmlinux.x86el" "vmlinux x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.x86el" "external/EMBA_Live_bins/vmlinux.x86el"
@@ -129,15 +129,6 @@ IL10_system_emulator() {
       y|Y )
 
       mkdir -p external/EMBA_Live_bins
-
-      # to ensure old EMBA versions do not completeley break - remove this at the beginning of 2023
-      mkdir -p external/firmae/
-      if [[ "$IN_DOCKER" -eq 1 ]]; then
-        ln -s /external/EMBA_Live_bins /external/firmae/binaries
-      else
-        ln -s external/EMBA_Live_bins external/firmae/binaries
-      fi
-      # END - remove this at the beginning of 2023
 
       apt-get install "${INSTALL_APP_LIST[@]}" -y --no-install-recommends
 
@@ -210,8 +201,8 @@ IL10_system_emulator() {
       download_file "vmlinux.mips64n32eb" "vmlinux mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64n32eb.4" "external/EMBA_Live_bins/vmlinux.mips64n32eb.4"
       download_file "vmlinux.mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64r2eb.4" "external/EMBA_Live_bins/vmlinux.mips64r2eb.4"
       download_file "vmlinux.mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64r2el.4" "external/EMBA_Live_bins/vmlinux.mips64r2el.4"
-      download_file "vmlinux.mips64v1eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64v1eb.4" "external/EMBA_Live_bins/vmlinux.mips64v1eb.4"
-      download_file "vmlinux.mips64v1el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64v1el.4" "external/EMBA_Live_bins/vmlinux.mips64v1el.4"
+      download_file "vmlinux.mips64v1eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64v1eb" "external/EMBA_Live_bins/vmlinux.mips64v1eb.4"
+      download_file "vmlinux.mips64v1el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64v1el" "external/EMBA_Live_bins/vmlinux.mips64v1el.4"
       download_file "vmlinux.mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mipseb.4" "external/EMBA_Live_bins/vmlinux.mipseb.4"
       download_file "vmlinux.mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mipsel.4" "external/EMBA_Live_bins/vmlinux.mipsel.4"
       download_file "vmlinux.x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.x86el" "external/EMBA_Live_bins/vmlinux.x86el"

--- a/installer/IL10_system_emulator.sh
+++ b/installer/IL10_system_emulator.sh
@@ -106,6 +106,7 @@ IL10_system_emulator() {
     print_file_info "vmlinux.mipseb" "vmlinux mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mipseb.4" "external/EMBA_Live_bins/vmlinux.mipseb.4"
     print_file_info "vmlinux.mipsel" "vmlinux mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mipsel.4" "external/EMBA_Live_bins/vmlinux.mipsel.4"
     print_file_info "vmlinux.x86el" "vmlinux x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.x86el" "external/EMBA_Live_bins/vmlinux.x86el"
+    print_file_info "bzImage.x86el" "bzImage x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/bzImage.x86el" "external/EMBA_Live_bins/bzImage.x86el"
 
     if [[ "$LIST_DEP" -eq 1 ]] || [[ $DOCKER_SETUP -eq 1 ]] ; then
       ANSWER=("n")
@@ -185,6 +186,7 @@ IL10_system_emulator() {
       download_file "vmlinux.mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mipseb.4" "external/EMBA_Live_bins/vmlinux.mipseb.4"
       download_file "vmlinux.mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mipsel.4" "external/EMBA_Live_bins/vmlinux.mipsel.4"
       download_file "vmlinux.x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.x86el" "external/EMBA_Live_bins/vmlinux.x86el"
+      download_file "bzImage.x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/bzImage.x86el" "external/EMBA_Live_bins/bzImage.x86el"
       ;;
     esac
   fi

--- a/installer/IL10_system_emulator.sh
+++ b/installer/IL10_system_emulator.sh
@@ -32,36 +32,80 @@ IL10_system_emulator() {
     print_tool_info "uml-utilities" 1
     print_tool_info "util-linux" 1
     print_tool_info "vlan" 1
+    print_tool_info "qemu-utils" 1
+    print_tool_info "qemu-system" 1
+    print_tool_info "qemu-system-common" 1
     print_tool_info "qemu-system-arm" 1
     print_tool_info "qemu-system-mips" 1
     print_tool_info "qemu-system-x86" 1
-    print_tool_info "qemu-utils" 1
+    print_tool_info "qemu-system-ppc" 1
+    print_tool_info "qemu-system-misc" 1
     print_tool_info "hping3" 1
     print_tool_info "traceroute" 1
 
-    # future use:
-    # print_file_info "vmlinux.mipsel.2" "FirmAE - Linux kernel 2.6 - MIPSel" "https://github.com/pr0v3rbs/FirmAE_kernel-v2.6/releases/download/v1.0/vmlinux.mipsel.2" "external/firmae/binaries/vmlinux.mipsel.2"
-    # print_file_info "vmlinux.mipseb.2" "FirmAE - Linux kernel 2.6 - MIPSeb" "https://github.com/pr0v3rbs/FirmAE_kernel-v2.6/releases/download/v1.0/vmlinux.mipseb.2" "external/firmae/binaries/vmlinux.mipseb.2"
-    print_file_info "vmlinux.mipsel.4" "FirmAE - Linux kernel 4.1 - MIPSel" "https://github.com/pr0v3rbs/FirmAE_kernel-v4.1/releases/download/v1.0/vmlinux.mipsel.4" "external/firmae/binaries/vmlinux.mipsel.4"
-    print_file_info "vmlinux.mipseb.4" "FirmAE - Linux kernel 4.1 - MIPSeb" "https://github.com/pr0v3rbs/FirmAE_kernel-v4.1/releases/download/v1.0/vmlinux.mipseb.4" "external/firmae/binaries/vmlinux.mipseb.4"
+    # BusyBox - https://busybox.net/downloads/busybox-1.29.3.tar.bz2
+    print_file_info "busybox.armel" "busybox ARMel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.armel" "external/EMBA_Live_bins/busybox.armel"
+    print_file_info "busybox.armelhf" "busybox ARMel hard float" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.armelhf" "external/EMBA_Live_bins/busybox.armelhf"
+    print_file_info "busybox.mips64n32eb" "busybox mips64n32eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mips64n32eb" "external/EMBA_Live_bins/busybox.mips64n32eb"
+    print_file_info "busybox.mips64n32el" "busybox mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mips64n32el" "external/EMBA_Live_bins/busybox.mips64n32el"
+    print_file_info "busybox.mips64r2eb" "busybox mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mips64r2eb" "external/EMBA_Live_bins/busybox.mips64r2eb"
+    print_file_info "busybox.mips64r2el" "busybox mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mips64r2el" "external/EMBA_Live_bins/busybox.mips64r2el"
+    print_file_info "busybox.mipseb" "busybox mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mipseb" "external/EMBA_Live_bins/busybox.mipseb"
+    print_file_info "busybox.mipsel" "busybox mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mipsel" "external/EMBA_Live_bins/busybox.mipsel"
+    print_file_info "busybox.x86el" "busybox x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.x86el" "external/EMBA_Live_bins/busybox.x86el"
 
-    print_file_info "zImage.armel" "FirmAE - Linux kernel 4.1 - ARMel" "https://github.com/pr0v3rbs/FirmAE_kernel-v4.1/releases/download/v1.0/zImage.armel" "external/firmae/binaries/zImage.armel"
-    print_file_info "vmlinux.armel" "FirmAE - Linux kernel 4.1 - ARMel" "https://github.com/pr0v3rbs/FirmAE_kernel-v4.1/releases/download/v1.0/vmlinux.armel" "external/firmae/binaries/vmlinux.armel"
+    # Console - https://github.com/EMBA-support-repos/firmadyne-console
+    print_file_info "console.armel" "console ARMel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.armel" "external/EMBA_Live_bins/console.armel"
+    print_file_info "console.armelhf" "console ARMel hard float" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.armelhf" "external/EMBA_Live_bins/console.armelhf"
+    print_file_info "console.mips64n32eb" "console mips64n32eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mips64n32eb" "external/EMBA_Live_bins/console.mips64n32eb"
+    print_file_info "console.mips64n32el" "console mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mips64n32el" "external/EMBA_Live_bins/console.mips64n32el"
+    print_file_info "console.mips64r2eb" "console mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mips64r2eb" "external/EMBA_Live_bins/console.mips64r2eb"
+    print_file_info "console.mips64r2el" "console mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mips64r2el" "external/EMBA_Live_bins/console.mips64r2el"
+    print_file_info "console.mipseb" "console mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mipseb" "external/EMBA_Live_bins/console.mipseb"
+    print_file_info "console.mipsel" "console mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mipsel" "external/EMBA_Live_bins/console.mipsel"
+    print_file_info "console.x86el" "console x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.x86el" "external/EMBA_Live_bins/console.x86el"
 
-    print_file_info "busybox.armel" "FirmAE - busybox - ARMel" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/busybox.armel" "external/firmae/binaries/busybox.armel"
-    print_file_info "busybox.mipseb" "FirmAE - busybox - MIPSeb" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/busybox.mipseb" "external/firmae/binaries/busybox.mipseb"
-    print_file_info "busybox.mipsel" "FirmAE - busybox - MIPSel" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/busybox.mipsel" "external/firmae/binaries/busybox.mipsel"
+    # libnvram - https://github.com/EMBA-support-repos/FirmAE-libnvram
+    print_file_info "libnvram.so.armel" "libnvram.so ARMel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.armel" "external/EMBA_Live_bins/libnvram.so.armel"
+    print_file_info "libnvram.so.armelhf" "libnvram.so ARMel hard float" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.armelhf" "external/EMBA_Live_bins/libnvram.so.armelhf"
+    print_file_info "libnvram.so.mips64n32eb" "libnvram.so mips64n32eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mips64n32eb" "external/EMBA_Live_bins/libnvram.so.mips64n32eb"
+    print_file_info "libnvram.so.mips64n32el" "libnvram.so mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mips64n32el" "external/EMBA_Live_bins/libnvram.so.mips64n32el"
+    print_file_info "libnvram.so.mips64r2eb" "libnvram.so mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mips64r2eb" "external/EMBA_Live_bins/libnvram.so.mips64r2eb"
+    print_file_info "libnvram.so.mips64r2el" "libnvram.so mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mips64r2el" "external/EMBA_Live_bins/libnvram.so.mips64r2el"
+    print_file_info "libnvram.so.mipseb" "libnvram.so mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mipseb" "external/EMBA_Live_bins/libnvram.so.mipseb"
+    print_file_info "libnvram.so.mipsel" "libnvram.so mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mipsel" "external/EMBA_Live_bins/libnvram.so.mipsel"
+    print_file_info "libnvram.so.x86el" "libnvram.so x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.x86el" "external/EMBA_Live_bins/libnvram.so.x86el"
 
-    print_file_info "console.armel" "FirmAE - Console - ARMel" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/console.armel" "external/firmae/binaries/console.armel"
-    print_file_info "console.mipseb" "FirmAE - Console - MIPSeb" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/console.mipseb" "external/firmae/binaries/console.mipseb"
-    print_file_info "console.mipsel" "FirmAE - Console - MIPSel" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/console.mipsel" "external/firmae/binaries/console.mipsel"
+    # libnvram_ioctl - https://github.com/EMBA-support-repos/FirmAE-libnvram
+    print_file_info "libnvram_ioctl.so.armel" "libnvram_ioctl.so ARMel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.armel" "external/EMBA_Live_bins/libnvram_ioctl.so.armel"
+    print_file_info "libnvram_ioctl.so.armelhf" "libnvram_ioctl.so ARMel hard float" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.armelhf" "external/EMBA_Live_bins/libnvram_ioctl.so.armelhf"
+    print_file_info "libnvram_ioctl.so.mips64n32eb" "libnvram_ioctl.so mips64n32eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mips64n32eb" "external/EMBA_Live_bins/libnvram_ioctl.so.mips64n32eb"
+    print_file_info "libnvram_ioctl.so.mips64n32el" "libnvram_ioctl.so mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mips64n32el" "external/EMBA_Live_bins/libnvram_ioctl.so.mips64n32el"
+    print_file_info "libnvram_ioctl.so.mips64r2eb" "libnvram_ioctl.so mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mips64r2eb" "external/EMBA_Live_bins/libnvram_ioctl.so.mips64r2eb"
+    print_file_info "libnvram_ioctl.so.mips64r2el" "libnvram_ioctl.so mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mips64r2el" "external/EMBA_Live_bins/libnvram_ioctl.so.mips64r2el"
+    print_file_info "libnvram_ioctl.so.mipseb" "libnvram_ioctl.so mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mipseb" "external/EMBA_Live_bins/libnvram_ioctl.so.mipseb"
+    print_file_info "libnvram_ioctl.so.mipsel" "libnvram_ioctl.so mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mipsel" "external/EMBA_Live_bins/libnvram_ioctl.so.mipsel"
+    print_file_info "libnvram_ioctl.so.x86el" "libnvram_ioctl.so x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.x86el" "external/EMBA_Live_bins/libnvram_ioctl.so.x86el"
 
-    print_file_info "libnvram.so.armel" "FirmAE - libnvram - ARMel" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/libnvram.so.armel" "external/firmae/binaries/libnvram.so.armel"
-    print_file_info "libnvram.so.mipseb" "FirmAE - libnvram - MIPSeb" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/libnvram.so.mipseb" "external/firmae/binaries/libnvram.so.mipseb"
-    print_file_info "libnvram.so.mipsel" "FirmAE - libnvram - MIPSel" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/libnvram.so.mipsel" "external/firmae/binaries/libnvram.so.mipsel"
-    print_file_info "libnvram_ioctl.so.armel" "FirmAE - libnvram_ioctl - ARMel" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/libnvram_ioctl.so.armel" "external/firmae/binaries/libnvram_ioctl.so.armel"
-    print_file_info "libnvram_ioctl.so.mipseb" "FirmAE - libnvram_ioctl - MIPSeb" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/libnvram_ioctl.so.mipseb" "external/firmae/binaries/libnvram_ioctl.so.mipseb"
-    print_file_info "libnvram_ioctl.so.mipsel" "FirmAE - libnvram_ioctl - MIPSel" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/libnvram_ioctl.so.mipsel" "external/firmae/binaries/libnvram_ioctl.so.mipsel"
+    # strace - https://github.com/EMBA-support-repos/strace
+    print_file_info "strace.armel" "strace ARMel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/strace.armel" "external/EMBA_Live_bins/strace.armel"
+    print_file_info "strace.armelhf" "strace ARMel hard float" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/strace.armelhf" "external/EMBA_Live_bins/strace.armelhf"
+    # print_file_info "strace.mips64n32eb" "strace mips64n32eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/strace.mips64n32eb" "external/EMBA_Live_bins/strace.mips64n32eb"
+    # print_file_info "strace.mips64n32el" "strace mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/strace.mips64n32el" "external/EMBA_Live_bins/strace.mips64n32el"
+    print_file_info "strace.mips64r2eb" "strace mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/strace.mips64r2eb" "external/EMBA_Live_bins/strace.mips64r2eb"
+    print_file_info "strace.mips64r2el" "strace mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/strace.mips64r2el" "external/EMBA_Live_bins/strace.mips64r2el"
+    print_file_info "strace.mipseb" "strace mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/strace.mipseb" "external/EMBA_Live_bins/strace.mipseb"
+    print_file_info "strace.mipsel" "strace mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/strace.mipsel" "external/EMBA_Live_bins/strace.mipsel"
+    print_file_info "strace.x86el" "strace x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/strace.x86el" "external/EMBA_Live_bins/strace.x86el"
+
+    # Linux Kernel 4.1.17 - https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1
+    print_file_info "zImage.armel" "zImage armel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/zImage.armel" "external/EMBA_Live_bins/zImage.armel"
+    print_file_info "zImage.armelhf" "zImage armelhf" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/zImage.armelhf" "external/EMBA_Live_bins/zImage.armelhf"print_file_info "vmlinux.mips64n32eb" "vmlinux mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64n32eb.4" "external/EMBA_Live_bins/vmlinux.mips64n32eb.4"
+    print_file_info "vmlinux.mips64r2eb" "vmlinux mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64r2eb.4" "external/EMBA_Live_bins/vmlinux.mips64r2eb.4"
+    print_file_info "vmlinux.mips64r2el" "vmlinux mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64r2el.4" "external/EMBA_Live_bins/vmlinux.mips64r2el.4"
+    print_file_info "vmlinux.mipseb" "vmlinux mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mipseb.4" "external/EMBA_Live_bins/vmlinux.mipseb.4"
+    print_file_info "vmlinux.mipsel" "vmlinux mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mipsel.4" "external/EMBA_Live_bins/vmlinux.mipsel.4"
+    print_file_info "vmlinux.x86el" "vmlinux x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.x86el" "external/EMBA_Live_bins/vmlinux.x86el"
 
     if [[ "$LIST_DEP" -eq 1 ]] || [[ $DOCKER_SETUP -eq 1 ]] ; then
       ANSWER=("n")
@@ -73,33 +117,74 @@ IL10_system_emulator() {
     case ${ANSWER:0:1} in
       y|Y )
 
-      mkdir -p external/firmae/binaries
+      mkdir -p external/EMBA_Live_bins
 
       apt-get install "${INSTALL_APP_LIST[@]}" -y --no-install-recommends
 
-      # download_file "vmlinux.mipsel.2" "https://github.com/pr0v3rbs/FirmAE_kernel-v2.6/releases/download/v1.0/vmlinux.mipsel.2" "external/firmae/binaries/vmlinux.mipsel.2"
-      # download_file "vmlinux.mipseb.2" "https://github.com/pr0v3rbs/FirmAE_kernel-v2.6/releases/download/v1.0/vmlinux.mipseb.2" "external/firmae/binaries/vmlinux.mipseb.2"
-      download_file "vmlinux.mipsel.4" "https://github.com/pr0v3rbs/FirmAE_kernel-v4.1/releases/download/v1.0/vmlinux.mipsel.4" "external/firmae/binaries/vmlinux.mipsel.4"
-      download_file "vmlinux.mipseb.4" "https://github.com/pr0v3rbs/FirmAE_kernel-v4.1/releases/download/v1.0/vmlinux.mipseb.4" "external/firmae/binaries/vmlinux.mipseb.4"
+      # BusyBox - https://busybox.net/downloads/busybox-1.29.3.tar.bz2
+      download_file "busybox.armel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.armel" "external/EMBA_Live_bins/busybox.armel"
+      download_file "busybox.armelhf" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.armelhf" "external/EMBA_Live_bins/busybox.armelhf"
+      download_file "busybox.mips64n32eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mips64n32eb" "external/EMBA_Live_bins/busybox.mips64n32eb"
+      download_file "busybox.mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mips64n32el" "external/EMBA_Live_bins/busybox.mips64n32el"
+      download_file "busybox.mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mips64r2eb" "external/EMBA_Live_bins/busybox.mips64r2eb"
+      download_file "busybox.mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mips64r2el" "external/EMBA_Live_bins/busybox.mips64r2el"
+      download_file "busybox.mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mipseb" "external/EMBA_Live_bins/busybox.mipseb"
+      download_file "busybox.mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mipsel" "external/EMBA_Live_bins/busybox.mipsel"
+      download_file "busybox.x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.x86el" "external/EMBA_Live_bins/busybox.x86el"
 
-      download_file "zImage.armel" "https://github.com/pr0v3rbs/FirmAE_kernel-v4.1/releases/download/v1.0/zImage.armel" "external/firmae/binaries/zImage.armel"
-      download_file "vmlinux.armel" "https://github.com/pr0v3rbs/FirmAE_kernel-v4.1/releases/download/v1.0/vmlinux.armel" "external/firmae/binaries/vmlinux.armel"
+      # Console - https://github.com/EMBA-support-repos/firmadyne-console
+      download_file "console.armel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.armel" "external/EMBA_Live_bins/console.armel"
+      download_file "console.armelhf" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.armelhf" "external/EMBA_Live_bins/console.armelhf"
+      download_file "console.mips64n32eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mips64n32eb" "external/EMBA_Live_bins/console.mips64n32eb"
+      download_file "console.mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mips64n32el" "external/EMBA_Live_bins/console.mips64n32el"
+      download_file "console.mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mips64r2eb" "external/EMBA_Live_bins/console.mips64r2eb"
+      download_file "console.mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mips64r2el" "external/EMBA_Live_bins/console.mips64r2el"
+      download_file "console.mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mipseb" "external/EMBA_Live_bins/console.mipseb"
+      download_file "console.mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mipsel" "external/EMBA_Live_bins/console.mipsel"
+      download_file "console.x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.x86el" "external/EMBA_Live_bins/console.x86el"
 
-      download_file "busybox.armel" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/busybox.armel" "external/firmae/binaries/busybox.armel"
-      download_file "busybox.mipseb" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/busybox.mipseb" "external/firmae/binaries/busybox.mipseb"
-      download_file "busybox.mipsel" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/busybox.mipsel" "external/firmae/binaries/busybox.mipsel"
+      # libnvram - https://github.com/EMBA-support-repos/FirmAE-libnvram
+      download_file "libnvram.so.armel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.armel" "external/EMBA_Live_bins/libnvram.so.armel"
+      download_file "libnvram.so.armelhf" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.armelhf" "external/EMBA_Live_bins/libnvram.so.armelhf"
+      download_file "libnvram.so.mips64n32eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mips64n32eb" "external/EMBA_Live_bins/libnvram.so.mips64n32eb"
+      download_file "libnvram.so.mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mips64n32el" "external/EMBA_Live_bins/libnvram.so.mips64n32el"
+      download_file "libnvram.so.mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mips64r2eb" "external/EMBA_Live_bins/libnvram.so.mips64r2eb"
+      download_file "libnvram.so.mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mips64r2el" "external/EMBA_Live_bins/libnvram.so.mips64r2el"
+      download_file "libnvram.so.mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mipseb" "external/EMBA_Live_bins/libnvram.so.mipseb"
+      download_file "libnvram.so.mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mipsel" "external/EMBA_Live_bins/libnvram.so.mipsel"
+      download_file "libnvram.so.x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.x86el" "external/EMBA_Live_bins/libnvram.so.x86el"
 
-      download_file "console.armel" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/console.armel" "external/firmae/binaries/console.armel"
-      download_file "console.mipseb" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/console.mipseb" "external/firmae/binaries/console.mipseb"
-      download_file "console.mipsel" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/console.mipsel" "external/firmae/binaries/console.mipsel"
+      # libnvram_ioctl - https://github.com/EMBA-support-repos/FirmAE-libnvram
+      download_file "libnvram_ioctl.so.armel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.armel" "external/EMBA_Live_bins/libnvram_ioctl.so.armel"
+      download_file "libnvram_ioctl.so.armelhf" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.armelhf" "external/EMBA_Live_bins/libnvram_ioctl.so.armelhf"
+      download_file "libnvram_ioctl.so.mips64n32eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mips64n32eb" "external/EMBA_Live_bins/libnvram_ioctl.so.mips64n32eb"
+      download_file "libnvram_ioctl.so.mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mips64n32el" "external/EMBA_Live_bins/libnvram_ioctl.so.mips64n32el"
+      download_file "libnvram_ioctl.so.mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mips64r2eb" "external/EMBA_Live_bins/libnvram_ioctl.so.mips64r2eb"
+      download_file "libnvram_ioctl.so.mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mips64r2el" "external/EMBA_Live_bins/libnvram_ioctl.so.mips64r2el"
+      download_file "libnvram_ioctl.so.mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mipseb" "external/EMBA_Live_bins/libnvram_ioctl.so.mipseb"
+      download_file "libnvram_ioctl.so.mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mipsel" "external/EMBA_Live_bins/libnvram_ioctl.so.mipsel"
+      download_file "libnvram_ioctl.so.x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.x86el" "external/EMBA_Live_bins/libnvram_ioctl.so.x86el"
 
-      download_file "libnvram.so.armel" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/libnvram.so.armel" "external/firmae/binaries/libnvram.so.armel"
-      download_file "libnvram.so.mipseb" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/libnvram.so.mipseb" "external/firmae/binaries/libnvram.so.mipseb"
-      download_file "libnvram.so.mipsel" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/libnvram.so.mipsel" "external/firmae/binaries/libnvram.so.mipsel"
-      download_file "libnvram_ioctl.so.armel" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/libnvram_ioctl.so.armel" "external/firmae/binaries/libnvram_ioctl.so.armel"
-      download_file "libnvram_ioctl.so.mipseb" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/libnvram_ioctl.so.mipseb" "external/firmae/binaries/libnvram_ioctl.so.mipseb"
-      download_file "libnvram_ioctl.so.mipsel" "https://github.com/pr0v3rbs/FirmAE/releases/download/v1.0/libnvram_ioctl.so.mipsel" "external/firmae/binaries/libnvram_ioctl.so.mipsel"
+      # strace - https://github.com/EMBA-support-repos/strace
+      download_file "strace.armel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/strace.armel" "external/EMBA_Live_bins/strace.armel"
+      download_file "strace.armelhf" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/strace.armelhf" "external/EMBA_Live_bins/strace.armelhf"
+      # download_file "strace.mips64n32eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/strace.mips64n32eb" "external/EMBA_Live_bins/strace.mips64n32eb"
+      # download_file "strace.mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/strace.mips64n32el" "external/EMBA_Live_bins/strace.mips64n32el"
+      download_file "strace.mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/strace.mips64r2eb" "external/EMBA_Live_bins/strace.mips64r2eb"
+      download_file "strace.mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/strace.mips64r2el" "external/EMBA_Live_bins/strace.mips64r2el"
+      download_file "strace.mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/strace.mipseb" "external/EMBA_Live_bins/strace.mipseb"
+      download_file "strace.mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/strace.mipsel" "external/EMBA_Live_bins/strace.mipsel"
+      download_file "strace.x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/strace.x86el" "external/EMBA_Live_bins/strace.x86el"
 
+      # Linux Kernel 4.1.17 - https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1
+      download_file "zImage.armel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/zImage.armel" "external/EMBA_Live_bins/zImage.armel"
+      download_file "zImage.armelhf" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/zImage.armelhf" "external/EMBA_Live_bins/zImage.armelhf"
+      download_file "vmlinux.mips64n32eb" "vmlinux mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64n32eb.4" "external/EMBA_Live_bins/vmlinux.mips64n32eb.4"
+      download_file "vmlinux.mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64r2eb.4" "external/EMBA_Live_bins/vmlinux.mips64r2eb.4"
+      download_file "vmlinux.mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64r2el.4" "external/EMBA_Live_bins/vmlinux.mips64r2el.4"
+      download_file "vmlinux.mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mipseb.4" "external/EMBA_Live_bins/vmlinux.mipseb.4"
+      download_file "vmlinux.mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mipsel.4" "external/EMBA_Live_bins/vmlinux.mipsel.4"
+      download_file "vmlinux.x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.x86el" "external/EMBA_Live_bins/vmlinux.x86el"
       ;;
     esac
   fi

--- a/installer/IL10_system_emulator.sh
+++ b/installer/IL10_system_emulator.sh
@@ -50,6 +50,8 @@ IL10_system_emulator() {
     print_file_info "busybox.mips64n32el" "busybox mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mips64n32el" "external/EMBA_Live_bins/busybox.mips64n32el"
     print_file_info "busybox.mips64r2eb" "busybox mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mips64r2eb" "external/EMBA_Live_bins/busybox.mips64r2eb"
     print_file_info "busybox.mips64r2el" "busybox mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mips64r2el" "external/EMBA_Live_bins/busybox.mips64r2el"
+    print_file_info "busybox.mips64v1el" "busybox mips64v1el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mips64v1el" "external/EMBA_Live_bins/busybox.mips64v1el"
+    print_file_info "busybox.mips64v1eb" "busybox mips64v1eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mips64v1el" "external/EMBA_Live_bins/busybox.mips64v1eb"
     print_file_info "busybox.mipseb" "busybox mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mipseb" "external/EMBA_Live_bins/busybox.mipseb"
     print_file_info "busybox.mipsel" "busybox mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mipsel" "external/EMBA_Live_bins/busybox.mipsel"
     print_file_info "busybox.x86el" "busybox x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.x86el" "external/EMBA_Live_bins/busybox.x86el"
@@ -61,6 +63,8 @@ IL10_system_emulator() {
     print_file_info "console.mips64n32el" "console mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mips64n32el" "external/EMBA_Live_bins/console.mips64n32el"
     print_file_info "console.mips64r2eb" "console mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mips64r2eb" "external/EMBA_Live_bins/console.mips64r2eb"
     print_file_info "console.mips64r2el" "console mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mips64r2el" "external/EMBA_Live_bins/console.mips64r2el"
+    print_file_info "console.mips64v1el" "console mips64v1el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mips64v1el" "external/EMBA_Live_bins/console.mips64v1el"
+    print_file_info "console.mips64v1eb" "console mips64v1eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mips64v1eb" "external/EMBA_Live_bins/console.mips64v1eb"
     print_file_info "console.mipseb" "console mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mipseb" "external/EMBA_Live_bins/console.mipseb"
     print_file_info "console.mipsel" "console mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mipsel" "external/EMBA_Live_bins/console.mipsel"
     print_file_info "console.x86el" "console x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.x86el" "external/EMBA_Live_bins/console.x86el"
@@ -72,6 +76,8 @@ IL10_system_emulator() {
     print_file_info "libnvram.so.mips64n32el" "libnvram.so mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mips64n32el" "external/EMBA_Live_bins/libnvram.so.mips64n32el"
     print_file_info "libnvram.so.mips64r2eb" "libnvram.so mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mips64r2eb" "external/EMBA_Live_bins/libnvram.so.mips64r2eb"
     print_file_info "libnvram.so.mips64r2el" "libnvram.so mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mips64r2el" "external/EMBA_Live_bins/libnvram.so.mips64r2el"
+    print_file_info "libnvram.so.mips64v1el" "libnvram.so mips64v1el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mips64v1el" "external/EMBA_Live_bins/libnvram.so.mips64v1el"
+    print_file_info "libnvram.so.mips64v1eb" "libnvram.so mips64v1eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mips64v1eb" "external/EMBA_Live_bins/libnvram.so.mips64v1eb"
     print_file_info "libnvram.so.mipseb" "libnvram.so mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mipseb" "external/EMBA_Live_bins/libnvram.so.mipseb"
     print_file_info "libnvram.so.mipsel" "libnvram.so mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mipsel" "external/EMBA_Live_bins/libnvram.so.mipsel"
     print_file_info "libnvram.so.x86el" "libnvram.so x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.x86el" "external/EMBA_Live_bins/libnvram.so.x86el"
@@ -83,6 +89,8 @@ IL10_system_emulator() {
     print_file_info "libnvram_ioctl.so.mips64n32el" "libnvram_ioctl.so mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mips64n32el" "external/EMBA_Live_bins/libnvram_ioctl.so.mips64n32el"
     print_file_info "libnvram_ioctl.so.mips64r2eb" "libnvram_ioctl.so mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mips64r2eb" "external/EMBA_Live_bins/libnvram_ioctl.so.mips64r2eb"
     print_file_info "libnvram_ioctl.so.mips64r2el" "libnvram_ioctl.so mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mips64r2el" "external/EMBA_Live_bins/libnvram_ioctl.so.mips64r2el"
+    print_file_info "libnvram_ioctl.so.mips64v1el" "libnvram_ioctl.so mips64v1el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mips64v1el" "external/EMBA_Live_bins/libnvram_ioctl.so.mips64v1el"
+    print_file_info "libnvram_ioctl.so.mips64v1eb" "libnvram_ioctl.so mips64v1eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mips64v1eb" "external/EMBA_Live_bins/libnvram_ioctl.so.mips64v1eb"
     print_file_info "libnvram_ioctl.so.mipseb" "libnvram_ioctl.so mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mipseb" "external/EMBA_Live_bins/libnvram_ioctl.so.mipseb"
     print_file_info "libnvram_ioctl.so.mipsel" "libnvram_ioctl.so mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mipsel" "external/EMBA_Live_bins/libnvram_ioctl.so.mipsel"
     print_file_info "libnvram_ioctl.so.x86el" "libnvram_ioctl.so x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.x86el" "external/EMBA_Live_bins/libnvram_ioctl.so.x86el"
@@ -103,6 +111,8 @@ IL10_system_emulator() {
     print_file_info "zImage.armelhf" "zImage armelhf" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/zImage.armelhf" "external/EMBA_Live_bins/zImage.armelhf"print_file_info "vmlinux.mips64n32eb" "vmlinux mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64n32eb.4" "external/EMBA_Live_bins/vmlinux.mips64n32eb.4"
     print_file_info "vmlinux.mips64r2eb" "vmlinux mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64r2eb.4" "external/EMBA_Live_bins/vmlinux.mips64r2eb.4"
     print_file_info "vmlinux.mips64r2el" "vmlinux mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64r2el.4" "external/EMBA_Live_bins/vmlinux.mips64r2el.4"
+    print_file_info "vmlinux.mips64v1el" "vmlinux mips64v1el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64v1el.4" "external/EMBA_Live_bins/vmlinux.mips64v1el.4"
+    print_file_info "vmlinux.mips64v1eb" "vmlinux mips64v1eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64v1eb.4" "external/EMBA_Live_bins/vmlinux.mips64v1eb.4"
     print_file_info "vmlinux.mipseb" "vmlinux mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mipseb.4" "external/EMBA_Live_bins/vmlinux.mipseb.4"
     print_file_info "vmlinux.mipsel" "vmlinux mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mipsel.4" "external/EMBA_Live_bins/vmlinux.mipsel.4"
     print_file_info "vmlinux.x86el" "vmlinux x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.x86el" "external/EMBA_Live_bins/vmlinux.x86el"
@@ -122,7 +132,11 @@ IL10_system_emulator() {
 
       # to ensure old EMBA versions do not completeley break - remove this at the beginning of 2023
       mkdir -p external/firmae/
-      ln -s external/EMBA_Live_bins external/firmae/binaries
+      if [[ "$IN_DOCKER" -eq 1 ]]; then
+        ln -s /external/EMBA_Live_bins /external/firmae/binaries
+      else
+        ln -s external/EMBA_Live_bins external/firmae/binaries
+      fi
       # END - remove this at the beginning of 2023
 
       apt-get install "${INSTALL_APP_LIST[@]}" -y --no-install-recommends
@@ -134,6 +148,8 @@ IL10_system_emulator() {
       download_file "busybox.mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mips64n32el" "external/EMBA_Live_bins/busybox.mips64n32el"
       download_file "busybox.mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mips64r2eb" "external/EMBA_Live_bins/busybox.mips64r2eb"
       download_file "busybox.mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mips64r2el" "external/EMBA_Live_bins/busybox.mips64r2el"
+      download_file "busybox.mips64v1eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mips64v1eb" "external/EMBA_Live_bins/busybox.mips64v1eb"
+      download_file "busybox.mips64v1el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mips64v1el" "external/EMBA_Live_bins/busybox.mips64v1el"
       download_file "busybox.mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mipseb" "external/EMBA_Live_bins/busybox.mipseb"
       download_file "busybox.mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.mipsel" "external/EMBA_Live_bins/busybox.mipsel"
       download_file "busybox.x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/busybox.x86el" "external/EMBA_Live_bins/busybox.x86el"
@@ -145,6 +161,8 @@ IL10_system_emulator() {
       download_file "console.mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mips64n32el" "external/EMBA_Live_bins/console.mips64n32el"
       download_file "console.mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mips64r2eb" "external/EMBA_Live_bins/console.mips64r2eb"
       download_file "console.mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mips64r2el" "external/EMBA_Live_bins/console.mips64r2el"
+      download_file "console.mips64v1eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mips64v1eb" "external/EMBA_Live_bins/console.mips64v1eb"
+      download_file "console.mips64v1el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mips64v1el" "external/EMBA_Live_bins/console.mips64v1el"
       download_file "console.mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mipseb" "external/EMBA_Live_bins/console.mipseb"
       download_file "console.mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.mipsel" "external/EMBA_Live_bins/console.mipsel"
       download_file "console.x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/console.x86el" "external/EMBA_Live_bins/console.x86el"
@@ -156,6 +174,8 @@ IL10_system_emulator() {
       download_file "libnvram.so.mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mips64n32el" "external/EMBA_Live_bins/libnvram.so.mips64n32el"
       download_file "libnvram.so.mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mips64r2eb" "external/EMBA_Live_bins/libnvram.so.mips64r2eb"
       download_file "libnvram.so.mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mips64r2el" "external/EMBA_Live_bins/libnvram.so.mips64r2el"
+      download_file "libnvram.so.mips64v1eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mips64v1eb" "external/EMBA_Live_bins/libnvram.so.mips64v1eb"
+      download_file "libnvram.so.mips64v1el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mips64v1el" "external/EMBA_Live_bins/libnvram.so.mips64v1el"
       download_file "libnvram.so.mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mipseb" "external/EMBA_Live_bins/libnvram.so.mipseb"
       download_file "libnvram.so.mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.mipsel" "external/EMBA_Live_bins/libnvram.so.mipsel"
       download_file "libnvram.so.x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram.so.x86el" "external/EMBA_Live_bins/libnvram.so.x86el"
@@ -167,6 +187,8 @@ IL10_system_emulator() {
       download_file "libnvram_ioctl.so.mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mips64n32el" "external/EMBA_Live_bins/libnvram_ioctl.so.mips64n32el"
       download_file "libnvram_ioctl.so.mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mips64r2eb" "external/EMBA_Live_bins/libnvram_ioctl.so.mips64r2eb"
       download_file "libnvram_ioctl.so.mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mips64r2el" "external/EMBA_Live_bins/libnvram_ioctl.so.mips64r2el"
+      download_file "libnvram_ioctl.so.mips64v1eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mips64v1eb" "external/EMBA_Live_bins/libnvram_ioctl.so.mips64v1eb"
+      download_file "libnvram_ioctl.so.mips64v1el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mips64v1el" "external/EMBA_Live_bins/libnvram_ioctl.so.mips64v1el"
       download_file "libnvram_ioctl.so.mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mipseb" "external/EMBA_Live_bins/libnvram_ioctl.so.mipseb"
       download_file "libnvram_ioctl.so.mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.mipsel" "external/EMBA_Live_bins/libnvram_ioctl.so.mipsel"
       download_file "libnvram_ioctl.so.x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/libnvram_ioctl.so.x86el" "external/EMBA_Live_bins/libnvram_ioctl.so.x86el"
@@ -188,6 +210,8 @@ IL10_system_emulator() {
       download_file "vmlinux.mips64n32eb" "vmlinux mips64n32el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64n32eb.4" "external/EMBA_Live_bins/vmlinux.mips64n32eb.4"
       download_file "vmlinux.mips64r2eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64r2eb.4" "external/EMBA_Live_bins/vmlinux.mips64r2eb.4"
       download_file "vmlinux.mips64r2el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64r2el.4" "external/EMBA_Live_bins/vmlinux.mips64r2el.4"
+      download_file "vmlinux.mips64v1eb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64v1eb.4" "external/EMBA_Live_bins/vmlinux.mips64v1eb.4"
+      download_file "vmlinux.mips64v1el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mips64v1el.4" "external/EMBA_Live_bins/vmlinux.mips64v1el.4"
       download_file "vmlinux.mipseb" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mipseb.4" "external/EMBA_Live_bins/vmlinux.mipseb.4"
       download_file "vmlinux.mipsel" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.mipsel.4" "external/EMBA_Live_bins/vmlinux.mipsel.4"
       download_file "vmlinux.x86el" "https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/download/all-new-binaries/vmlinux.x86el" "external/EMBA_Live_bins/vmlinux.x86el"

--- a/installer/IL10_system_emulator.sh
+++ b/installer/IL10_system_emulator.sh
@@ -120,6 +120,11 @@ IL10_system_emulator() {
 
       mkdir -p external/EMBA_Live_bins
 
+      # to ensure old EMBA versions do not completeley break - remove this at the beginning of 2023
+      mkdir -p external/firmae/
+      ln -s external/EMBA_Live_bins external/firmae/binaries
+      # END - remove this at the beginning of 2023
+
       apt-get install "${INSTALL_APP_LIST[@]}" -y --no-install-recommends
 
       # BusyBox - https://busybox.net/downloads/busybox-1.29.3.tar.bz2

--- a/installer/IP12_avm_freetz_ng_extract.sh
+++ b/installer/IP12_avm_freetz_ng_extract.sh
@@ -39,6 +39,7 @@ IP12_avm_freetz_ng_extract() {
     print_tool_info "libtool" 1
     print_tool_info "libtool-bin" 1
     print_tool_info "pkg-config" 1
+    print_tool_info "pkgconf" 1
     print_tool_info "python3" 1
     print_tool_info "unzip" 1
     print_tool_info "subversion" 1

--- a/installer/IP61_unblob.sh
+++ b/installer/IP61_unblob.sh
@@ -43,8 +43,10 @@ IP61_unblob() {
     print_tool_info "zlib1g-dev" 1
     print_tool_info "libmagic1" 1
     print_tool_info "libhyperscan5" 1
+    print_tool_info "libhyperscan-dev" 1
     print_tool_info "zstd" 1
     print_tool_info "python3-magic" 1
+    print_tool_info "pkg-config" 1
 
     print_file_info "sasquatch_1.0_amd64.deb" "sasquatch_1.0_amd64.deb" "https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v1.0/sasquatch_1.0_amd64.deb" "external/sasquatch_1.0_amd64.deb"
 
@@ -79,9 +81,9 @@ IP61_unblob() {
         UNBLOB_PATH=$(poetry env info --path)
 
         # Temp solution to install hyperscan in a recent version which is installable on Kali:
-        sed -i 's/hyperscan\ =\ \"0.2.0\"//' pyproject.toml
-        poetry env use "$UNBLOB_PATH"
-        poetry add hyperscan
+        # sed -i 's/hyperscan\ =\ \"0.2.0\"//' pyproject.toml
+        # poetry env use "$UNBLOB_PATH"
+        # poetry add hyperscan
 
         if [[ -f "$UNBLOB_PATH""/bin/unblob" ]]; then
           export PATH=$PATH:"$UNBLOB_PATH""/bin"

--- a/installer/IP61_unblob.sh
+++ b/installer/IP61_unblob.sh
@@ -47,6 +47,7 @@ IP61_unblob() {
     print_tool_info "zstd" 1
     print_tool_info "python3-magic" 1
     print_tool_info "pkg-config" 1
+    print_tool_info "pkgconf" 1
 
     print_file_info "sasquatch_1.0_amd64.deb" "sasquatch_1.0_amd64.deb" "https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v1.0/sasquatch_1.0_amd64.deb" "external/sasquatch_1.0_amd64.deb"
 

--- a/modules/L10_system_emulation.sh
+++ b/modules/L10_system_emulation.sh
@@ -44,8 +44,7 @@ L10_system_emulation() {
     if [[ "$ARCH" == "MIPS" || "$ARCH" == "ARM" || "$ARCH" == "x86" || "$ARCH" == "MIPS64"* ]]; then
       enable_firmae_arbitration
 
-      export FIRMAE_DIR="$EXT_DIR""/firmae"
-      export BINARY_DIR="$FIRMAE_DIR/binaries"
+      export BINARY_DIR="$EXT_DIR/EMBA_Live_bins"
       FIRMWARE_PATH_orig="$(abs_path "$FIRMWARE_PATH_BAK")"
       LOG_PATH_MODULE=$(abs_path "$LOG_PATH_MODULE")
       R_PATH_CNT=1
@@ -887,6 +886,7 @@ identify_networking_emulation() {
     QEMU_ROOTFS="/dev/sda1"
     QEMU_NETWORK="-netdev socket,id=net0,listen=:2000 -device e1000,netdev=net0 -netdev socket,id=net1,listen=:2001 -device e1000,netdev=net1 -netdev socket,id=net2,listen=:2002 -device e1000,netdev=net2 -netdev socket,id=net3,listen=:2003 -device e1000,netdev=net3"
   elif [[ "$ARCH_END" == "nios2" ]]; then
+    # not tested
     KERNEL_="vmlinux"
     QEMU_BIN="qemu-system-nios2"
     MACHINE="10m50-ghrd"
@@ -1504,6 +1504,7 @@ run_emulated_system() {
     QEMU_BIN="qemu-system-x86_64"
     QEMU_MACHINE="pc-i440fx-3.1"
   elif [[ "$ARCH_END" == "nios2" ]]; then
+    # not tested
     KERNEL="$BINARY_DIR/vmlinux.$ARCH_END"
     QEMU_BIN="qemu-system-nios2"
     QEMU_MACHINE="10m50-ghrd"

--- a/modules/L10_system_emulation.sh
+++ b/modules/L10_system_emulation.sh
@@ -41,7 +41,7 @@ L10_system_emulation() {
     export MODULE_SUB_PATH="$MOD_DIR"/"${FUNCNAME[0]}"
     S25_LOG="s25_kernel_check.txt"
 
-    if [[ "$ARCH" == "MIPS" || "$ARCH" == "ARM" || "$ARCH" == "x86" || "$ARCH" == "MIPS64"* || "$ARCH" == "NIOS2" ]]; then
+    if [[ "$ARCH" == "MIPS" || "$ARCH" == "ARM" || "$ARCH" == "ARM64" || "$ARCH" == "x86" || "$ARCH" == "MIPS64"* || "$ARCH" == "NIOS2" ]]; then
 
       # WARNING: false was never tested ;)
       # Could be interesting for future extensions
@@ -68,7 +68,7 @@ L10_system_emulation() {
             ARCH_END="$ARCH_END""hf"
           fi
 
-          if [[ "$ARCH_END" == "armbe"* ]] || [[ "$ARCH_END" == "mips64_3"* ]] || [[ "$ARCH_END" == "mips64n32"* ]]; then
+          if [[ "$ARCH_END" == "armbe"* ]] || [[ "$ARCH_END" == "mips64_3"* ]] || [[ "$ARCH_END" == "mips64n32"* ]] || [[ "$ARCH_END" == "arm64"* ]]; then
             print_output "[-] Found NOT supported architecture $ORANGE$ARCH_END$NC"
             print_output "[-] Please open a new issue here: https://github.com/e-m-b-a/emba/issues"
             UNSUPPORTED_ARCH=1
@@ -890,6 +890,13 @@ identify_networking_emulation() {
     QEMU_NETWORK="-device virtio-net-device,netdev=net0 -netdev user,id=net0"
     #QEMU_NETWORK="-device virtio-net-device,netdev=net1 -netdev socket,listen=:2000,id=net1 -device virtio-net-device,netdev=net2 -netdev socket,listen=:2001,id=net2 -device virtio-net-device,netdev=net3 -netdev socket,listen=:2002,id=net3 -device virtio-net-device,netdev=net4 -netdev socket,listen=:2003,id=net4"
     #QEMU_PARAMS="-audiodev driver=none,id=none"
+  elif [[ "$ARCH_END" == "arm64el"* ]]; then
+    KERNEL_="vmlinux"
+    QEMU_BIN="qemu-system-aarch64"
+    MACHINE="virt"
+    QEMU_DISK="-drive if=none,file=$IMAGE,format=raw,id=rootfs -device virtio-blk-device,drive=rootfs"
+    QEMU_ROOTFS="/dev/vda1"
+    QEMU_NETWORK="-device virtio-net-device,netdev=net0 -netdev user,id=net0"
   elif [[ "$ARCH_END" == "x86el"* ]]; then
     KERNEL_="bzImage"
     QEMU_BIN="qemu-system-x86_64"
@@ -1507,6 +1514,10 @@ run_emulated_system() {
   elif [[ "$ARCH_END" == "armel"* ]]; then
     KERNEL="$BINARY_DIR/zImage.$ARCH_END"
     QEMU_BIN="qemu-system-arm"
+    QEMU_MACHINE="virt"
+  elif [[ "$ARCH_END" == "arm64el"* ]]; then
+    KERNEL="$BINARY_DIR/vmlinux.$ARCH_END"
+    QEMU_BIN="qemu-system-aarch64"
     QEMU_MACHINE="virt"
   elif [[ "$ARCH_END" == "x86el"* ]]; then
     KERNEL="$BINARY_DIR/bzImage.$ARCH_END"

--- a/modules/L10_system_emulation.sh
+++ b/modules/L10_system_emulation.sh
@@ -323,6 +323,7 @@ main_emulation() {
   export IPS_INT_VLAN=()
 
   for INIT_FILE in "${INIT_FILES[@]}"; do
+    INIT_FNAME=$(basename "$INIT_FILE")
     # this is the main init entry - we modify it later for special cases:
     KINIT="rdinit=/firmadyne/preInit.sh"
 
@@ -445,8 +446,8 @@ main_emulation() {
 
     local F_STARTUP=0
     if [[ -f "$LOG_PATH_MODULE"/qemu.initial.serial.log ]]; then
-      cat "$LOG_PATH_MODULE"/qemu.initial.serial.log >> "$LOG_PATH_MODULE"/qemu.initial.serial_"$IMAGE_NAME".log
-      write_link "$LOG_PATH_MODULE"/qemu.initial.serial_"$IMAGE_NAME".log
+      cat "$LOG_PATH_MODULE"/qemu.initial.serial.log >> "$LOG_PATH_MODULE"/qemu.initial.serial_"$IMAGE_NAME"_"$INIT_FNAME".log
+      write_link "$LOG_PATH_MODULE"/qemu.initial.serial_"$IMAGE_NAME"_"$INIT_FNAME".log
 
       ###############################################################################################
       # if we were running into issues with the network identification we poke with rdinit vs init:
@@ -464,7 +465,7 @@ main_emulation() {
       # if we are running into a kernel panic during the network detection we are going to check if the
       # panic is caused from an init failure. If so, we are trying the other init kernel command (init vs rdinit)
       if [[ "${PANICS[*]}" == *"Kernel panic - not syncing: Attempted to kill init!"* || "${PANICS[*]}" == *"Kernel panic - not syncing: No working init found."* ]]; then
-        mv "$LOG_PATH_MODULE"/qemu.initial.serial.log "$LOG_PATH_MODULE"/qemu.initial.serial_"$IMAGE_NAME"_base_init.log
+        mv "$LOG_PATH_MODULE"/qemu.initial.serial.log "$LOG_PATH_MODULE"/qemu.initial.serial_"$IMAGE_NAME"_"$INIT_FNAME"_base_init.log
         if [[ "$KINIT" == "rdinit="* ]]; then
           print_output "[*] Warning: Kernel panic with failed rdinit found - testing init"
           # strip rd from rdinit
@@ -480,8 +481,8 @@ main_emulation() {
 
         print_output "[*] Firmware $ORANGE$IMAGE_NAME$NC finished for identification of the network configuration"
         if [[ -f "$LOG_PATH_MODULE"/qemu.initial.serial.log ]]; then
-          mv "$LOG_PATH_MODULE"/qemu.initial.serial.log "$LOG_PATH_MODULE"/qemu.initial.serial_"$IMAGE_NAME"_new_init.log
-          write_link "$LOG_PATH_MODULE"/qemu.initial.serial_"$IMAGE_NAME"_new_init.log
+          mv "$LOG_PATH_MODULE"/qemu.initial.serial.log "$LOG_PATH_MODULE"/qemu.initial.serial_"$IMAGE_NAME"_"$INIT_FNAME"_new_init.log
+          write_link "$LOG_PATH_MODULE"/qemu.initial.serial_"$IMAGE_NAME"_"$INIT_FNAME"_new_init.log
         else
           print_output "[-] No Qemu log file generated ... some weird error occured"
         fi
@@ -491,7 +492,7 @@ main_emulation() {
       #elif [[ "$F_STARTUP" -eq 0 && "$NETWORK_MODE" == "None" && "${#IPS_INT_VLAN[@]}" -lt 2 ]] || \
       #  [[ "$F_STARTUP" -eq 0 && "$NETWORK_MODE" == "default" && "${#IPS_INT_VLAN[@]}" -lt 2 ]]; then
       elif [[ "$F_STARTUP" -eq 0 && "$NETWORK_MODE" == "None" ]] || [[ "$F_STARTUP" -eq 0 && "$NETWORK_MODE" == "default" ]]; then
-        mv "$LOG_PATH_MODULE"/qemu.initial.serial.log "$LOG_PATH_MODULE"/qemu.initial.serial_"$IMAGE_NAME"_base_init.log
+        mv "$LOG_PATH_MODULE"/qemu.initial.serial.log "$LOG_PATH_MODULE"/qemu.initial.serial_"$IMAGE_NAME"_"$INIT_FNAME"_base_init.log
         if [[ "$KINIT" == "rdinit="* ]]; then
           print_output "[*] Warning: Unknown EMBA startup found via rdinit - testing init"
           # strip rd from rdinit
@@ -524,8 +525,8 @@ main_emulation() {
 
         print_output "[*] Firmware $ORANGE$IMAGE_NAME$NC finished for identification of the network configuration"
         if [[ -f "$LOG_PATH_MODULE"/qemu.initial.serial.log ]]; then
-          mv "$LOG_PATH_MODULE"/qemu.initial.serial.log "$LOG_PATH_MODULE"/qemu.initial.serial_"$IMAGE_NAME"_new_init.log
-          write_link "$LOG_PATH_MODULE"/qemu.initial.serial_"$IMAGE_NAME"_new_init.log
+          mv "$LOG_PATH_MODULE"/qemu.initial.serial.log "$LOG_PATH_MODULE"/qemu.initial.serial_"$IMAGE_NAME"_"$INIT_FNAME"_new_init.log
+          write_link "$LOG_PATH_MODULE"/qemu.initial.serial_"$IMAGE_NAME"_"$INIT_FNAME"_new_init.log
         else
           print_output "[-] No Qemu log file generated ... some weird error occured"
         fi
@@ -628,14 +629,14 @@ main_emulation() {
         reset_network_emulation "$EXECUTE"
               
         if [[ -f "$LOG_PATH_MODULE"/qemu.final.serial.log ]]; then
-          mv "$LOG_PATH_MODULE"/qemu.final.serial.log "$LOG_PATH_MODULE"/qemu.final.serial_"$IMAGE_NAME"-"$IPS_INT_VLAN_CFG_mod".log
+          mv "$LOG_PATH_MODULE"/qemu.final.serial.log "$LOG_PATH_MODULE"/qemu.final.serial_"$IMAGE_NAME"-"$IPS_INT_VLAN_CFG_mod"-"$INIT_FNAME".log
         fi
 
         if [[ "$SYS_ONLINE" -eq 1 ]]; then
           print_ln
           print_output "[+] System emulation was successful."
-          if [[ -f "$LOG_PATH_MODULE"/qemu.final.serial_"$IMAGE_NAME"-"$IPS_INT_VLAN_CFG_mod".log ]]; then
-            print_output "[+] System should be available via IP $ORANGE$IP_ADDRESS_$GREEN." "" "$LOG_PATH_MODULE"/qemu.final.serial_"$IMAGE_NAME"-"$IPS_INT_VLAN_CFG_mod".log
+          if [[ -f "$LOG_PATH_MODULE"/qemu.final.serial_"$IMAGE_NAME"-"$IPS_INT_VLAN_CFG_mod"-"$INIT_FNAME".log ]]; then
+            print_output "[+] System should be available via IP $ORANGE$IP_ADDRESS_$GREEN." "" "$LOG_PATH_MODULE"/qemu.final.serial_"$IMAGE_NAME"-"$IPS_INT_VLAN_CFG_mod"-"$INIT_FNAME".log
           else
             print_output "[+] System should be available via IP $ORANGE$IP_ADDRESS_$GREEN."
           fi
@@ -662,8 +663,8 @@ main_emulation() {
         if [[ -f "$LOG_PATH_MODULE"/nvram/nvram_files_final_ ]]; then
           mv "$LOG_PATH_MODULE"/nvram/nvram_files_final_ "$LOG_PATH_MODULE"/nvram/nvram_files_"$IMAGE_NAME".bak
         fi
-        if ! [[ -f "$LOG_PATH_MODULE/qemu.final.serial_$IMAGE_NAME-$IPS_INT_VLAN_CFG_mod.log" ]]; then
-          print_output "[!] Warning: No Qemu log file generated for $ORANGE$IMAGE_NAME-$IPS_INT_VLAN_CFG_mod$NC"
+        if ! [[ -f "$LOG_PATH_MODULE/qemu.final.serial_$IMAGE_NAME-$IPS_INT_VLAN_CFG_mod-$INIT_FNAME.log" ]]; then
+          print_output "[!] Warning: No Qemu log file generated for $ORANGE$IMAGE_NAME-$IPS_INT_VLAN_CFG_mod-$INIT_FNAME$NC"
         fi
       done
     else
@@ -1764,7 +1765,7 @@ create_emulation_archive() {
     tar -czvf "$LOG_PATH_MODULE"/archive-"$IMAGE_NAME"-"$RANDOM_ID".tar.gz "$ARCHIVE_PATH"
     if [[ -f "$LOG_PATH_MODULE"/archive-"$IMAGE_NAME"-"$RANDOM_ID".tar.gz ]]; then
       print_ln
-      print_output "[*] Qemu emulation archive created in log directory." "" "$LOG_PATH_MODULE/archive-$IMAGE_NAME-$RANDOM_ID.tar.gz"
+      print_output "[*] Qemu emulation archive created in log directory: $ORANGE$ARCHIVE_PATH$NC" "" "$LOG_PATH_MODULE/archive-$IMAGE_NAME-$RANDOM_ID.tar.gz"
       print_ln
     fi
   else
@@ -1918,7 +1919,7 @@ write_results() {
     local FIRMWARE_PATH_orig
     FIRMWARE_PATH_orig="$(cat "$TMP_DIR"/fw_name.log)"
   fi
-  echo "$FIRMWARE_PATH_orig;$RESULT_SOURCE;Booted $BOOTED; ICMP $ICMP; TCP-0 $TCP_0;TCP $TCP; IP address: $IP_ADDRESS_; Network mode: $NETWORK_MODE" >> "$LOG_DIR"/emulator_online_results.log
+  echo "$FIRMWARE_PATH_orig;$RESULT_SOURCE;Booted $BOOTED; ICMP $ICMP; TCP-0 $TCP_0;TCP $TCP; IP address: $IP_ADDRESS_; Network mode: $NETWORK_MODE ($NETWORK_DEVICE/$ETH_INT/$INIT_FILE)" >> "$LOG_DIR"/emulator_online_results.log
   print_bar ""
 }
 

--- a/modules/L10_system_emulation.sh
+++ b/modules/L10_system_emulation.sh
@@ -42,7 +42,10 @@ L10_system_emulation() {
     S25_LOG="s25_kernel_check.txt"
 
     if [[ "$ARCH" == "MIPS" || "$ARCH" == "ARM" || "$ARCH" == "x86" || "$ARCH" == "MIPS64"* ]]; then
-      enable_firmae_arbitration
+
+      # WARNING: false was never tested ;)
+      # Could be interesting for future extensions
+      set_firmae_arbitration "true"
 
       export BINARY_DIR="$EXT_DIR/EMBA_Live_bins"
       FIRMWARE_PATH_orig="$(abs_path "$FIRMWARE_PATH_BAK")"
@@ -1238,6 +1241,7 @@ store_interface_details() {
   local ETH_INT__="${3:-eth0}"
   local VLAN_ID__="${4:-NONE}"
   local NETWORK_MODE__="${5:-bridge}"
+  NETWORK_DEVICE__="br-lan"
 
   IPS_INT_VLAN+=( "$IP_ADDRESS__"\;"$NETWORK_DEVICE__"\;"$ETH_INT__"\;"$VLAN_ID__"\;"$NETWORK_MODE__" )
   print_output "[+] Interface details detected: IP address: $ORANGE$IP_ADDRESS__$GREEN / bridge dev: $ORANGE$NETWORK_DEVICE__$GREEN / network device: $ORANGE$ETH_INT__$GREEN / vlan id: $ORANGE$VLAN_ID__$GREEN / network mode: $ORANGE$NETWORK_MODE__$NC"
@@ -1923,13 +1927,14 @@ write_results() {
   print_bar ""
 }
 
-enable_firmae_arbitration() {
+set_firmae_arbitration() {
+  FIRMAE_STATE="${1:-true}"
   # FirmAE arbitration - enable all mechanisms
-  export FIRMAE_BOOT=true
-  export FIRMAE_NET=true
-  export FIRMAE_NVRAM=true
-  export FIRMAE_KERNEL=true
-  export FIRMAE_ETC=true
+  export FIRMAE_BOOT="$FIRMAE_STATE"
+  export FIRMAE_NET="$FIRMAE_STATE"
+  export FIRMAE_NVRAM="$FIRMAE_STATE"
+  export FIRMAE_KERNEL="$FIRMAE_STATE"
+  export FIRMAE_ETC="$FIRMAE_STATE"
 }
 
 color_qemu_log() {

--- a/modules/L10_system_emulation.sh
+++ b/modules/L10_system_emulation.sh
@@ -41,7 +41,7 @@ L10_system_emulation() {
     export MODULE_SUB_PATH="$MOD_DIR"/"${FUNCNAME[0]}"
     S25_LOG="s25_kernel_check.txt"
 
-    if [[ "$ARCH" == "MIPS" || "$ARCH" == "ARM" || "$ARCH" == "ARM64" || "$ARCH" == "x86" || "$ARCH" == "MIPS64"* || "$ARCH" == "NIOS2" ]]; then
+    if [[ "$ARCH" == "MIPS" || "$ARCH" == "ARM" || "$ARCH" == "x86" || "$ARCH" == "MIPS64"* ]]; then
 
       # WARNING: false was never tested ;)
       # Could be interesting for future extensions
@@ -72,7 +72,7 @@ L10_system_emulation() {
             print_output "[-] Found NOT supported architecture $ORANGE$ARCH_END$NC"
             print_output "[-] Please open a new issue here: https://github.com/e-m-b-a/emba/issues"
             UNSUPPORTED_ARCH=1
-            #return
+            return
           fi
 
           # just in case we remove the return in the unsupported arch checker for testing:

--- a/modules/L10_system_emulation/fixImage.sh
+++ b/modules/L10_system_emulation/fixImage.sh
@@ -104,6 +104,10 @@ if [ "$FILECOUNT" -lt "5" ]; then
   "${TMP_BUSYBOX}" mknod -m 660 /dev/ttyS1 c 4 65
   "${TMP_BUSYBOX}" mknod -m 660 /dev/ttyS2 c 4 66
   "${TMP_BUSYBOX}" mknod -m 660 /dev/ttyS3 c 4 67
+  "${TMP_BUSYBOX}" mknod -m 660 /dev/myttyS0 c 4 64
+  "${TMP_BUSYBOX}" mknod -m 660 /dev/myttyS1 c 4 65
+  "${TMP_BUSYBOX}" mknod -m 660 /dev/myttyS2 c 4 66
+  "${TMP_BUSYBOX}" mknod -m 660 /dev/myttyS3 c 4 67
 
   # AVM:
   "${TMP_BUSYBOX}" mknod -m 600 /dev/ttyMSM0 c 251 0

--- a/modules/L10_system_emulation/inferFile.sh
+++ b/modules/L10_system_emulation/inferFile.sh
@@ -63,7 +63,7 @@ if ("${FIRMAE_BOOT}"); then
           "${BUSYBOX}" rm "${FILE}"
         fi
         # find original program from binary directories
-        "${BUSYBOX}" echo "${FILE}"
+        "${BUSYBOX}" echo "[*] Analysing ${FILE}"
         FILE_NAME=$("${BUSYBOX}" basename "${FILE}")
         if ("${BUSYBOX}" find /bin /sbin /usr/sbin /usr/sbin -type f -exec "${BUSYBOX}" grep -qr "${FILE_NAME}" {} \;); then
           TARGET_FILE=$("${BUSYBOX}" find /bin /sbin /usr/sbin /usr/sbin -type f -exec "${BUSYBOX}" egrep -rl "${FILE_NAME}" {} \; | "${BUSYBOX}" head -1)

--- a/modules/L10_system_emulation/inferFile.sh
+++ b/modules/L10_system_emulation/inferFile.sh
@@ -49,8 +49,7 @@ if ("${FIRMAE_BOOT}"); then
   if (( ${#arr[@]} )); then
     # convert to the unique array following the original order
     # shellcheck disable=SC2207,SC2016
-    #uniq_arr=($("${BUSYBOX}" tr ' ' '\n' <<< "${arr[@]}" | "${BUSYBOX}" awk '!u[$0]++' | "${BUSYBOX}" tr '\n' ' '))
-    mapfile -t uniq_arr < <("${BUSYBOX}" tr ' ' '\n' <<< "${arr[@]}" | "${BUSYBOX}" awk '!u[$0]++' | "${BUSYBOX}" tr '\n' ' ')
+    uniq_arr=($("${BUSYBOX}" tr ' ' '\n' <<< "${arr[@]}" | "${BUSYBOX}" awk '!u[$0]++' | "${BUSYBOX}" tr '\n' ' '))
     for FILE in "${uniq_arr[@]}"
     do
       if [ -d "${FILE}" ]; then

--- a/modules/L10_system_emulation/inferFile.sh
+++ b/modules/L10_system_emulation/inferFile.sh
@@ -25,7 +25,7 @@ if ("${FIRMAE_BOOT}"); then
       arr+=(/init)
     fi
   fi
-  for FILE in $("${BUSYBOX}" find / -name "preinitMT" -o -name "preinit" -o -name "rcS*" -o -name "rc.sysinit" -o -name "rc.local" -o -name "rc.common" -o -name "init")
+  for FILE in $("${BUSYBOX}" find / -name "preinitMT" -o -name "preinit" -o -name "rcS*" -o -name "rc.sysinit" -o -name "rc.local" -o -name "rc.common" -o -name "init" -o -name "linuxrc")
   do
     "${BUSYBOX}" echo "[*] Found boot file $FILE"
     arr+=("${FILE}")
@@ -35,15 +35,18 @@ if ("${FIRMAE_BOOT}"); then
   for FILE in $("${BUSYBOX}" find / -name "inittab" -type f)
   do
     "${BUSYBOX}" echo "[*] Found boot file $FILE"
-    # sysinit entry is the one to look for - we do not handle multiple entries!
+    # sysinit entry is the one to look for
     # shellcheck disable=SC2016
-    STARTUP_FILE=$("${BUSYBOX}" grep ":.*sysinit:" "$FILE" | "${BUSYBOX}" rev | "${BUSYBOX}" cut -d: -f1 | "${BUSYBOX}" rev | "${BUSYBOX}" awk '{print $1}')
-    "${BUSYBOX}" echo "[*] Found possible startup file $STARTUP_FILE"
-    if [ -e "${STARTUP_FILE}" ]; then
+    for STARTUP_FILE in $("${BUSYBOX}" grep ":.*sysinit:" "$FILE" | "${BUSYBOX}" rev | "${BUSYBOX}" cut -d: -f1 | "${BUSYBOX}" rev | "${BUSYBOX}" awk '{print $1}' | "${BUSYBOX}" sort -u)
+    do
+      "${BUSYBOX}" echo "[*] Found possible startup file $STARTUP_FILE"
       arr+=("${STARTUP_FILE}")
-    else
-      "${BUSYBOX}" echo "[-] Something went wrong with startup file $STARTUP_FILE"
-    fi
+      #if [ -e "${STARTUP_FILE}" ]; then
+      #  arr+=("${STARTUP_FILE}")
+      #else
+      #  "${BUSYBOX}" echo "[-] Something went wrong with startup file $STARTUP_FILE"
+      #fi
+    done
   done
 
   if (( ${#arr[@]} )); then

--- a/modules/L10_system_emulation/inferFile.sh
+++ b/modules/L10_system_emulation/inferFile.sh
@@ -25,7 +25,7 @@ if ("${FIRMAE_BOOT}"); then
       arr+=(/init)
     fi
   fi
-  for FILE in $("${BUSYBOX}" find / -name "preinitMT" -o -name "preinit" -o -name "rcS*" -o -name "rc.sysinit" -o -name "rc.local")
+  for FILE in $("${BUSYBOX}" find / -name "preinitMT" -o -name "preinit" -o -name "rcS*" -o -name "rc.sysinit" -o -name "rc.local" -o -name "rc.common" -o -name "init")
   do
     "${BUSYBOX}" echo "[*] Found boot file $FILE"
     arr+=("${FILE}")

--- a/modules/L10_system_emulation/network.sh
+++ b/modules/L10_system_emulation/network.sh
@@ -10,7 +10,7 @@ ACTION=$("${BUSYBOX}" cat /firmadyne/network_type)
 "${BUSYBOX}" echo "[*] Network configuration - ACTION: $ACTION" 
 
 if ("${FIRMAE_NET}"); then
-  "${BUSYBOX}" echo "[*] starting network configuration"
+  "${BUSYBOX}" echo "[*] Starting network configuration"
   "${BUSYBOX}" sleep 10
 
   if [ "${ACTION}" = "default" ]; then
@@ -36,8 +36,15 @@ if ("${FIRMAE_NET}"); then
     "${BUSYBOX}" sleep 5
 
     if [ "${ACTION}" = "normal" ]; then
+
       # shellcheck disable=SC2016
-      IP=$("${BUSYBOX}" ip addr show "${NET_BRIDGE}" | "${BUSYBOX}" grep -m1 "inet\b" | "${BUSYBOX}" awk '{print $2}' | "${BUSYBOX}" cut -d/ -f1)
+      if ("${BUSYBOX}" ip addr show "${NET_BRIDGE}" | "${BUSYBOX}" grep -m1 "inet\b" | "${BUSYBOX}" awk '{print $2}' | "${BUSYBOX}" cut -d/ -f1); then
+        IP=$("${BUSYBOX}" ip addr show "${NET_BRIDGE}" | "${BUSYBOX}" grep -m1 "inet\b" | "${BUSYBOX}" awk '{print $2}' | "${BUSYBOX}" cut -d/ -f1)
+        "${BUSYBOX}" echo "[*] Identified IP address: $IP"
+      else
+        IP=$("${BUSYBOX}" cat /firmadyne/ip_default)
+        "${BUSYBOX}" echo "[*] Setting default IP address: $IP"
+      fi
       # tplink TL-WA860RE_EU_UK_US__V5_171116
       "${BUSYBOX}" ifconfig "${NET_BRIDGE}" "${IP}"
       "${BUSYBOX}" ifconfig "${NET_INTERFACE}" 0.0.0.0 up
@@ -54,6 +61,7 @@ if ("${FIRMAE_NET}"); then
         WAN_BRIDGE=$("${BUSYBOX}" brctl show | "${BUSYBOX}" grep "eth0" | "${BUSYBOX}" awk '{print $1}')
         "${BUSYBOX}" brctl delif "${WAN_BRIDGE}" eth0
       fi
+
       # shellcheck disable=SC2016
       if ("${BUSYBOX}" ip addr show "${NET_BRIDGE}" | "${BUSYBOX}" grep -m1 "inet\b" | "${BUSYBOX}" awk '{print $2}' | "${BUSYBOX}" cut -d/ -f1); then
         IP=$("${BUSYBOX}" ip addr show "${NET_BRIDGE}" | "${BUSYBOX}" grep -m1 "inet\b" | "${BUSYBOX}" awk '{print $2}' | "${BUSYBOX}" cut -d/ -f1)

--- a/modules/L10_system_emulation/network.sh
+++ b/modules/L10_system_emulation/network.sh
@@ -55,7 +55,14 @@ if ("${FIRMAE_NET}"); then
         "${BUSYBOX}" brctl delif "${WAN_BRIDGE}" eth0
       fi
       # shellcheck disable=SC2016
-      IP=$("${BUSYBOX}" ip addr show "${NET_BRIDGE}" | "${BUSYBOX}" grep -m1 "inet\b" | "${BUSYBOX}" awk '{print $2}' | "${BUSYBOX}" cut -d/ -f1)
+      if ("${BUSYBOX}" ip addr show "${NET_BRIDGE}" | "${BUSYBOX}" grep -m1 "inet\b" | "${BUSYBOX}" awk '{print $2}' | "${BUSYBOX}" cut -d/ -f1); then
+        IP=$("${BUSYBOX}" ip addr show "${NET_BRIDGE}" | "${BUSYBOX}" grep -m1 "inet\b" | "${BUSYBOX}" awk '{print $2}' | "${BUSYBOX}" cut -d/ -f1)
+        "${BUSYBOX}" echo "[*] Identified IP address: $IP"
+      else
+        IP=$("${BUSYBOX}" cat /firmadyne/ip_default)
+        "${BUSYBOX}" echo "[*] Setting default IP address: $IP"
+      fi
+
       "${BUSYBOX}" ifconfig "${NET_BRIDGE}" "${IP}"
       "${BUSYBOX}" brctl addif "${NET_BRIDGE}" eth0
       "${BUSYBOX}" ifconfig "${NET_INTERFACE}" 0.0.0.0 up

--- a/modules/P02_firmware_bin_file_check.sh
+++ b/modules/P02_firmware_bin_file_check.sh
@@ -112,6 +112,7 @@ set_p02_default_exports() {
   #       an indicator if this could be some UEFI firmware for further processing
   export UEFI_AMI_CAPSULE=0
   export ZYXEL_ZIP=0
+  export QCOW_DETECTED=0
 }
 
 fw_bin_detector() {
@@ -157,6 +158,11 @@ fw_bin_detector() {
       export PATOOLS_INIT=1
       write_csv_log "basic compressed (patool)" "yes" "NA"
     fi
+  fi
+  if [[ "$FILE_BIN_OUT" == *"QEMU QCOW2 Image"* ]]; then
+    print_output "[+] Identified Qemu QCOW image - using QCOW extraction module"
+    export QCOW_DETECTED=1
+    write_csv_log "Qemu QCOW firmware detected" "yes" "NA"
   fi
   if [[ "$FILE_BIN_OUT" == *"VMware4 disk image"* ]]; then
     print_output "[+] Identified VMWware VMDK archive file - using VMDK extraction module"

--- a/modules/P02_firmware_bin_file_check.sh
+++ b/modules/P02_firmware_bin_file_check.sh
@@ -151,10 +151,10 @@ fw_bin_detector() {
   # if we have a zip, tgz, tar archive we are going to use the patools extractor
   if [[ "$FILE_BIN_OUT" == *"gzip compressed data"* || "$FILE_BIN_OUT" == *"Zip archive data"* || \
     "$FILE_BIN_OUT" == *"POSIX tar archive"* || "$FILE_BIN_OUT" == *"ISO 9660 CD-ROM filesystem data"* || \
-    "$FILE_BIN_OUT" == *"7-zip archive data"* ]]; then
+    "$FILE_BIN_OUT" == *"7-zip archive data"* || "$FILE_BIN_OUT" == *"XZ compressed data"* ]]; then
     # as the AVM images are also zip files we need to bypass it here:
     if [[ "$AVM_DETECTED" -ne 1 ]]; then
-      print_output "[+] Identified gzip/zip/tar/iso archive file - using patools extraction module"
+      print_output "[+] Identified gzip/zip/tar/iso/xz archive file - using patools extraction module"
       export PATOOLS_INIT=1
       write_csv_log "basic compressed (patool)" "yes" "NA"
     fi

--- a/modules/P23_qemu_qcow_mounter.sh
+++ b/modules/P23_qemu_qcow_mounter.sh
@@ -1,0 +1,115 @@
+#!/bin/bash -p
+
+# EMBA - EMBEDDED LINUX ANALYZER
+#
+# Copyright 2020-2022 Siemens Energy AG
+#
+# EMBA comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
+# welcome to redistribute it under the terms of the GNU General Public License.
+# See LICENSE file for usage of this software.
+#
+# EMBA is licensed under GPLv3
+#
+# Author(s): Michael Messner
+
+# Description: Mounts and extracts Qemu QCOS images
+# Pre-checker threading mode - if set to 1, these modules will run in threaded mode
+export PRE_THREAD_ENA=0
+
+P23_qemu_qcow_mounter() {
+  local NEG_LOG=0
+  if [[ "$BSD_UFS" -eq 1 ]]; then
+    module_log_init "${FUNCNAME[0]}"
+    module_title "Qemu QCOW filesystem extractor"
+    pre_module_reporter "${FUNCNAME[0]}"
+
+    print_output "[*] Connect to device $ORANGE$FIRMWARE_PATH$NC"
+
+    EXTRACTION_DIR="$LOG_DIR"/firmware/qemu_qcow_mount_filesystem/
+
+    qcow_extractor "$FIRMWARE_PATH" "$EXTRACTION_DIR"
+
+    if [[ "$FILES_QCOW_MOUNT" -gt 0 ]]; then
+      MD5_DONE_DEEP+=( "$(md5sum "$FIRMWARE_PATH" | awk '{print $1}')" )
+      export FIRMWARE_PATH="$LOG_DIR"/firmware/
+      backup_var "FIRMWARE_PATH" "$FIRMWARE_PATH"
+    fi
+    NEG_LOG=1
+    module_end_log "${FUNCNAME[0]}" "$NEG_LOG"
+    exit 1
+  fi
+}
+
+qcow_extractor() {
+  local QCOW_PATH_="${1:-}"
+  local EXTRACTION_DIR_="${2:-}"
+  local TMP_QCOW_MOUNT="$TMP_DIR""/qcow_mount_$RANDOM"
+  local DIRS_QCOW_MOUNT=0
+  FILES_QCOW_MOUNT=0
+
+  if ! [[ -f "$QCOW_PATH_" ]]; then
+    print_output "[-] No file for extraction provided"
+    return
+  fi
+
+  sub_module_title "Qemu QCOW filesystem extractor"
+
+  mkdir -p "$TMP_QCOW_MOUNT" 2>/dev/null || true
+  print_output "[*] Trying to mount $ORANGE$QCOW_PATH_$NC to $ORANGE$TMP_QCOW_MOUNT$NC directory"
+
+  if lsmod | grep -q nbd; then
+    rmmod nbd
+  fi
+  if ! [[ -d /var/lock ]]; then
+    mkdir /var/lock
+  fi
+  print_output "[*] Load kernel module ${ORANGE}nbd$NC."
+  modprobe nbd max_part=8
+  print_output "[*] Qemu disconnect device ${ORANGE}/dev/nbd$NC."
+  qemu-nbd --disconnect /dev/nbd0
+  sleep 5
+  ls -l /dev/nbd0*
+  print_output "[*] Qemu connect device ${ORANGE}/dev/nbd$NC."
+  qemu-nbd --connect=/dev/nbd0 "$QCOW_PATH_"
+
+  print_output "[*] Identification of partitions on ${ORANGE}/dev/nbd$NC."
+  mapfile -t NBD_DEVS < <(fdisk /dev/nbd0 -l | grep "^/dev/" | awk '{print $1}')
+  fdisk /dev/nbd0 -l
+
+  for NBD_DEV in "${NBD_DEVS[@]}"; do
+    print_output "[*] Extract data from partition $ORANGE$NBD_DEV$NC"
+    mount "$NBD_DEV" "$TMP_QCOW_MOUNT" || true
+
+    if mount | grep -q "$NBD_DEV"; then
+      EXTRACTION_DIR_FINAL="$EXTRACTION_DIR_"/"$(basename "$NBD_DEV")"
+      copy_qemu_nbd "$TMP_QCOW_MOUNT" "$EXTRACTION_DIR_FINAL"
+    fi
+
+    FILES_QCOW_MOUNT=$(find "$EXTRACTION_DIR_FINAL" -type f | wc -l)
+    DIRS_QCOW_MOUNT=$(find "$EXTRACTION_DIR_FINAL" -type d | wc -l)
+    print_output "[*] Extracted $ORANGE$FILES_QCOW_MOUNT$NC files and $ORANGE$DIRS_QCOW_MOUNT$NC directories from the firmware image."
+    write_csv_log "Extractor module" "Original file" "extracted file/dir" "file counter" "directory counter" "further details"
+    write_csv_log "Qemu QCOW filesystem extractor" "$QCOW_PATH_" "$EXTRACTION_DIR_FINAL" "$FILES_QCOW_MOUNT" "$DIRS_QCOW_MOUNT" "NA"
+
+    print_output "[*] Unmounting $ORANGE$TMP_QCOW_MOUNT$NC directory"
+    umount "$TMP_QCOW_MOUNT"
+  done
+  qemu-nbd --disconnect /dev/nbd0
+  rm -r "$TMP_QCOW_MOUNT"
+}
+
+copy_qemu_nbd() {
+  local SOURCE_CP="${1:-}"
+  local DEST_CP="${2:-}"
+  if ! [[ -d "$SOURCE_CP" ]]; then
+    return
+  fi
+
+  print_output "[*] Copying $ORANGE$SOURCE_CP$NC to firmware tmp directory ($ORANGE$DEST_CP$NC)"
+  mkdir -p "$DEST_CP" 2>/dev/null || true
+  cp -pri "$SOURCE_CP"/* "$DEST_CP" 2>/dev/null || true
+  print_ln
+  print_output "[*] Using the following firmware directory ($ORANGE$DEST_CP$NC) as base directory:"
+  find "$DEST_CP" -xdev -maxdepth 1 -ls | tee -a "$LOG_FILE"
+  print_ln
+}

--- a/modules/P60_firmware_bin_extractor.sh
+++ b/modules/P60_firmware_bin_extractor.sh
@@ -277,7 +277,7 @@ binwalk_deep_extract_helper() {
   # Matryoshka mode is first parameter: 1 - enable, 0 - disable
   local MATRYOSHKA_="${1:-0}"
   local FILE_TO_EXTRACT_="${2:-}"
-  local DEST_FILE_="${3:-$FIRMWARE_PATH_CP}"
+  local DEST_FILE_="${3:-}"
 
   if ! [[ -f "$FILE_TO_EXTRACT_" ]]; then
     print_output "[-] No file for extraction provided"

--- a/modules/P60_firmware_bin_extractor.sh
+++ b/modules/P60_firmware_bin_extractor.sh
@@ -243,6 +243,13 @@ deeper_extractor_helper() {
         else
           zyxel_zip_extractor "$FILE_TMP" "${FILE_TMP}_zyxel_enc_extracted"
         fi
+      elif [[ "$QCOW_DETECTED" -ne 0 ]]; then
+        if [[ "$THREADED" -eq 1 ]]; then
+          qcow_extractor "$FILE_TMP" "${FILE_TMP}_qemu_qcow_extracted" &
+          WAIT_PIDS_P20+=( "$!" )
+        else
+          qcow_extractor "$FILE_TMP" "${FILE_TMP}_qemu_qcow_extracted"
+        fi
 
       else
         # default case to binwalk

--- a/modules/P61_unblob_eval.sh
+++ b/modules/P61_unblob_eval.sh
@@ -46,7 +46,7 @@ P61_unblob_eval() {
     return
   fi
 
-  if ! command -v unblob 2>/dev/null; then
+  if ! command -v unblob >/dev/null; then
     print_output "[-] Unblob not correct installed - check your installation"
     return
   fi

--- a/modules/P61_unblob_eval.sh
+++ b/modules/P61_unblob_eval.sh
@@ -46,6 +46,11 @@ P61_unblob_eval() {
     return
   fi
 
+  if ! command -v unblob 2>/dev/null; then
+    print_output "[-] Unblob not correct installed - check your installation"
+    return
+  fi
+
   local FILES_EXT_UB=0
   local UNIQUE_FILES_UB=0
   local DIRS_EXT_UB=0
@@ -100,25 +105,7 @@ unblobber() {
   local OUTPUT_DIR_UNBLOB="${2:-}"
   local UNBLOB_BIN="unblob"
 
-  # find unblob installation - we move this later to the dependency checker
-
-  if ! command -v unblob && [[ -f "$EXT_DIR"/unblob/unblob_path.cfg ]]; then
-    # recover unblob installation - usually we are in the docker container
-    if ! [[ -d "$HOME"/.cache ]]; then
-      mkdir "$HOME"/.cache
-    fi
-    cp -pr "$EXT_DIR"/unblob/root_cache/* "$HOME"/.cache/
-    if [[ -e $(cat "$EXT_DIR"/unblob/unblob_path.cfg)/bin/"$UNBLOB_BIN" ]]; then
-      UNBLOB_PATH="$(cat "$EXT_DIR"/unblob/unblob_path.cfg)""/bin/"
-      export PATH=$PATH:"$UNBLOB_PATH"
-    else
-      print_output "[-] Cant find unblob installation - check your installation"
-      return
-    fi
-  else
-    print_output "[-] Cant find unblob installation - check your installation"
-    return
-  fi
+  # unblob should be checked in the dependency checker
 
   sub_module_title "Analyze binary firmware blob with unblob"
 

--- a/modules/S03_firmware_bin_base_analyzer.sh
+++ b/modules/S03_firmware_bin_base_analyzer.sh
@@ -77,7 +77,7 @@ os_identification() {
   write_log "[*] Initial OS guessing:"
   write_csv_log "Guessed OS" "confidential rating" "verified" "Linux root filesystems found"
 
-  OS_SEARCHER=("Linux" "FreeBSD" "VxWorks\|Wind" "FreeRTOS" "ADONIS" "eCos" "uC/OS" "SIPROTEC" "QNX" "CPU\ [34][12][0-9]-[0-9]" "CP443" "Sinamics" "UEFI")
+  OS_SEARCHER=("Linux" "FreeBSD" "VxWorks\|Wind" "FreeRTOS" "ADONIS" "eCos" "uC/OS" "SIPROTEC" "QNX" "CPU\ [34][12][0-9]-[0-9]" "CP443" "Sinamics" "UEFI" "HelenOS")
   print_dot
   declare -A OS_COUNTER=()
   local WAIT_PIDS_S03_1=()

--- a/modules/S13_weak_func_check.sh
+++ b/modules/S13_weak_func_check.sh
@@ -172,7 +172,7 @@ function_check_NIOS2(){
         "$OBJDUMP" -d "$BINARY_" | grep -E -A 2 -B 20 "call.*$FUNC_ADDR" 2> /dev/null >> "$FUNC_LOG" || true
       fi
       if [[ -f "$FUNC_LOG" ]] && [[ $(wc -l "$FUNC_LOG" | awk '{print $1}') -gt 0 ]] ; then
-        sed -i -r "s/^.*:.*($FUNC_ADDR).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
+        sed -i -r "s/^.*:.*($FUNC_ADDR).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG" || true
         COUNT_FUNC="$(grep -c "call.*""$FUNC_ADDR" "$FUNC_LOG"  2> /dev/null || true)"
         if [[ "$FUNCTION" == "strcpy" ]] ; then
           COUNT_STRLEN=$(grep -c "call.*$STRLEN_ADDR" "$FUNC_LOG"  2> /dev/null || true)
@@ -213,7 +213,7 @@ function_check_PPC32(){
         "$OBJDUMP" -d "$BINARY_" | grep -E -A 2 -B 20 "bl.*<$FUNCTION" 2> /dev/null >> "$FUNC_LOG" || true
       fi
       if [[ -f "$FUNC_LOG" ]] && [[ $(wc -l "$FUNC_LOG" | awk '{print $1}') -gt 0 ]] ; then
-        sed -i -r "s/^.*:.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
+        sed -i -r "s/^.*:.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG" || true
         COUNT_FUNC="$(grep -c "bl.*""$FUNCTION" "$FUNC_LOG"  2> /dev/null || true)"
         if [[ "$FUNCTION" == "strcpy" ]] ; then
           COUNT_STRLEN=$(grep -c "bl.*strlen" "$FUNC_LOG"  2> /dev/null || true)
@@ -295,7 +295,7 @@ function_check_ARM64() {
       "$OBJDUMP" -d "$BINARY_" | grep -A 2 -B 20 "[[:blank:]]bl[[:blank:]].*<$FUNCTION" 2> /dev/null >> "$FUNC_LOG" || true
     fi
     if [[ -f "$FUNC_LOG" ]] && [[ $(wc -l "$FUNC_LOG" | awk '{print $1}') -gt 0 ]] ; then
-      sed -i -r "s/^.*:.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
+      sed -i -r "s/^.*:.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG" || true
       COUNT_FUNC="$(grep -c "[[:blank:]]bl[[:blank:]].*<$FUNCTION" "$FUNC_LOG"  2> /dev/null || true)"
       if [[ "$FUNCTION" == "strcpy" ]] ; then
         COUNT_STRLEN=$(grep -c "[[:blank:]]bl[[:blank:]].*<strlen" "$FUNC_LOG"  2> /dev/null || true)
@@ -333,7 +333,7 @@ function_check_ARM32() {
       "$OBJDUMP" -d "$BINARY_" | grep -A 2 -B 20 "[[:blank:]]bl[[:blank:]].*<$FUNCTION" 2> /dev/null >> "$FUNC_LOG" || true
     fi
     if [[ -f "$FUNC_LOG" ]] && [[ $(wc -l "$FUNC_LOG" | awk '{print $1}') -gt 0 ]] ; then
-      sed -i -r "s/^.*:.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
+      sed -i -r "s/^.*:.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG" || true
       COUNT_FUNC="$(grep -c "[[:blank:]]bl[[:blank:]].*<$FUNCTION" "$FUNC_LOG"  2> /dev/null || true)"
       if [[ "$FUNCTION" == "strcpy" ]] ; then
         COUNT_STRLEN=$(grep -c "[[:blank:]]bl[[:blank:]].*<strlen" "$FUNC_LOG"  2> /dev/null || true)
@@ -372,7 +372,7 @@ function_check_x86() {
         "$OBJDUMP" -d "$BINARY_" | grep -E -A 2 -B 20 "call.*<$FUNCTION" 2> /dev/null >> "$FUNC_LOG" || true
       fi
       if [[ -f "$FUNC_LOG" ]] && [[ $(wc -l "$FUNC_LOG" | awk '{print $1}') -gt 0 ]] ; then
-        sed -i -r "s/^.*:.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
+        sed -i -r "s/^.*:.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG" || true
         COUNT_FUNC="$(grep -c -e "call.*$FUNCTION" "$FUNC_LOG"  2> /dev/null || true)"
         if [[ "$FUNCTION" == "strcpy" ]] ; then
           COUNT_STRLEN=$(grep -c "call.*strlen" "$FUNC_LOG"  2> /dev/null || true)
@@ -411,7 +411,7 @@ function_check_x86_64() {
         "$OBJDUMP" -d "$BINARY_" | grep -E -A 2 -B 20 "call.*<$FUNCTION" 2> /dev/null >> "$FUNC_LOG" || true
       fi
       if [[ -f "$FUNC_LOG" ]] && [[ $(wc -l "$FUNC_LOG" | awk '{print $1}') -gt 0 ]] ; then
-        sed -i -r "s/^.*:.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG"
+        sed -i -r "s/^.*:.*($FUNCTION).*/\x1b[31m&\x1b[0m/" "$FUNC_LOG" || true
         COUNT_FUNC="$(grep -c -e "call.*$FUNCTION" "$FUNC_LOG"  2> /dev/null || true)"
         if [[ "$FUNCTION" == "strcpy"  ]] ; then
           COUNT_STRLEN=$(grep -c "call.*strlen" "$FUNC_LOG"  2> /dev/null || true)

--- a/modules/S24_kernel_bin_identifier.sh
+++ b/modules/S24_kernel_bin_identifier.sh
@@ -251,9 +251,9 @@ check_kconfig() {
   print_output "[*] Testing kernel configuration file $ORANGE$KCONFIG_FILE$NC with kconfig-hardened-check"
   local KCONF_LOG=""
   KCONF_LOG="$LOG_PATH_MODULE/kconfig_hardening_check_$(basename "$KCONFIG_FILE").log"
-  "$KCONF_HARD_CHECKER" -c "$KCONFIG_FILE" | tee -a "$KCONF_LOG"
+  "$KCONF_HARD_CHECKER" -c "$KCONFIG_FILE" | tee -a "$KCONF_LOG" || true
   if [[ -f "$KCONF_LOG" ]]; then
-    FAILED_KSETTINGS=$(grep -c "FAIL: " "$KCONF_LOG")
+    FAILED_KSETTINGS=$(grep -c "FAIL: " "$KCONF_LOG" || true)
     if [[ "$FAILED_KSETTINGS" -gt 0 ]]; then
       print_output "[+] Found $ORANGE$FAILED_KSETTINGS$GREEN security related kernel settings which should be reviewed - $ORANGE$(print_path "$KCONFIG_FILE")$NC" "" "$KCONF_LOG"
       print_ln

--- a/modules/S50_authentication_check.sh
+++ b/modules/S50_authentication_check.sh
@@ -574,7 +574,7 @@ search_pam_configs() {
           ((AUTH_ISSUES+=1))
           print_output "[+] ""$(print_path "$FILE")"" exist"
           local FIND2
-          FIND2=$(grep "^auth.*ldap" "$FILE")
+          FIND2=$(grep "^auth.*ldap" "$FILE" || true)
           if [[ -n "$FIND2" ]] ; then
             print_output "[+] LDAP module present"
             print_output "$(indent "$(orange "$FIND2")")"

--- a/modules/S99_grepit.sh
+++ b/modules/S99_grepit.sh
@@ -125,9 +125,9 @@ grepit_search() {
   local LINES_OF_OUTPUT=0
   local GREP_COMMAND="grep"
   local LOG_DETAILS=1
-  local COMMENT="$1"
-  local EXAMPLE="$2"
-  local FALSE_POSITIVES_EXAMPLE="$3"
+  local COMMENT="${1:-NA}"
+  local EXAMPLE="${2:-NA}"
+  local FALSE_POSITIVES_EXAMPLE="${3:-NA}"
   local SEARCH_REGEX="$4"
   local OUTFILE="$5"
   if [[ -v 6 ]]; then


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fixes and features

* **What is the current behavior?** (You can also link to an open issue here)

limited kernels in L10 module
Qemu QCOW2 images are not extracted in a clean way

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

New kernels included (see also https://github.com/EMBA-support-repos/FirmAE_kernel-v4.1/releases/tag/all-new-binaries):
* x86
* ARMel hard float
* mips64v1

Qemu QCOW extractor

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Needs to be synced with docker image upload!
