### PR TITLE
Remove wget log during installation

### DIFF
--- a/installer/helpers.sh
+++ b/installer/helpers.sh
@@ -207,6 +207,9 @@ print_file_info()
   else
     echo -e "$ORANGE""${1:-}"" has already been downloaded.""$NC"
   fi
+  if [[ -f "./.wget.log" ]]; then
+    rm "./.wget.log" || true
+  fi
 }
 
 # download_file a b c

--- a/installer/helpers.sh
+++ b/installer/helpers.sh
@@ -233,6 +233,9 @@ download_file()
   if [[ -f "${3:-}" ]] && ! [[ -x "${3:-}" ]] ; then
     chmod +x "${3:-}"
   fi
+  if [[ -f "./.wget.log" ]]; then
+    rm "./.wget.log" || true
+  fi
 }
 
 # Source: https://stackoverflow.com/questions/4023830/how-to-compare-two-strings-in-dot-separated-version-format-in-bash


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

wget.log stays in main EMBA directory after installation.

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

We remove it now.
Closes https://github.com/e-m-b-a/emba/issues/415