### PR TITLE
Unblob it in case binwalk fails

### DIFF
--- a/helpers/helpers_emba_dependency_check.sh
+++ b/helpers/helpers_emba_dependency_check.sh
@@ -394,6 +394,7 @@ dependency_check()
     export MPLCONFIGDIR="$TMP_DIR"
 
     setup_unblob "unblob"
+    check_dep_tool "unrar" "unrar"
     setup_nikto
 
     # jtr

--- a/installer/IP99_binwalk_default.sh
+++ b/installer/IP99_binwalk_default.sh
@@ -68,6 +68,8 @@ IP99_binwalk_default() {
     # python-setuptools is needed for ubireader installation
     print_tool_info "python-setuptools" 1
     print_tool_info "srecord" 1
+    print_tool_info "unrar-free" 1
+    print_tool_info "unrar" 1
 
     print_pip_info "nose"
     print_pip_info "coverage"

--- a/modules/P61_unblob_eval.sh
+++ b/modules/P61_unblob_eval.sh
@@ -109,8 +109,8 @@ P61_unblob_eval() {
       mv "$OUTPUT_DIR_UNBLOB" "$LOG_DIR"/firmware/ || true
       detect_root_dir_helper "$LOG_DIR/firmware"
       print_ln
-      tree -sh "$LOG_DIR/firmware/unblob_extracted" | tee -a "$LOG_FILE"
     fi
+    tree -sh "$LOG_DIR/firmware/unblob_extracted" | tee -a "$LOG_FILE"
     print_ln
   fi
 

--- a/modules/P61_unblob_eval.sh
+++ b/modules/P61_unblob_eval.sh
@@ -69,7 +69,7 @@ P61_unblob_eval() {
   print_output "[*] Unblob module currently enabled - disable it in emba.sh setting the UNBLOB variable to 0"
 
   print_output "[!] INFO: This is an evaluation module for the extractor ${ORANGE}unblob - https://unblob.org/$MAGENTA."
-  print_output "[!] INFO: The results are currently not further used in the EMBA firmware analysis process (this will probably change in the future)."
+  print_output "[!] INFO: The results are currently only further used if the binwalk extraction process failes (this will probably change in the future)."
 
   export LINUX_PATH_COUNTER_UNBLOB=0
   local OUTPUT_DIR_UNBLOB="$LOG_PATH_MODULE"/unblob_extracted
@@ -104,7 +104,13 @@ P61_unblob_eval() {
     print_output "[*] Found $ORANGE$BINS$NC binaries."
     print_output "[*] Additionally the Linux path counter is $ORANGE$LINUX_PATH_COUNTER$NC."
     print_bar
-    tree -sh "$OUTPUT_DIR_UNBLOB" | tee -a "$LOG_FILE"
+    if [[ "$LINUX_PATH_COUNTER" -eq 0 ]] && [[ "$LINUX_PATH_COUNTER_UNBLOB" -gt 0 ]]; then
+      print_output "[+] Binwalk extraction failed - using Unblob results as additional source for further analysis"
+      mv "$OUTPUT_DIR_UNBLOB" "$LOG_DIR"/firmware/ || true
+      detect_root_dir_helper "$LOG_DIR/firmware"
+      print_ln
+      tree -sh "$LOG_DIR/firmware/unblob_extracted" | tee -a "$LOG_FILE"
+    fi
     print_ln
   fi
 

--- a/modules/S06_distribution_identification.sh
+++ b/modules/S06_distribution_identification.sh
@@ -144,6 +144,8 @@ get_csv_rule_distri() {
   # F5 BigIP
   VERSION_IDENTIFIER="$(echo "$VERSION_IDENTIFIER" | sed -r 's/big-ip\ ltm\ ([0-9]+(\.[0-9]+)+?)/f5:big-ip_local_traffic_manager:\1/')"
   VERSION_IDENTIFIER="$(echo "$VERSION_IDENTIFIER" | sed -r 's/big-ip\ asm\ ([0-9]+(\.[0-9]+)+?)/f5:big-ip_application_security_manager:\1/')"
+  # Yocto linux - e.g.: poky:(yocto:project:reference:distro):2.2:(morty)
+  VERSION_IDENTIFIER="$(echo "$VERSION_IDENTIFIER" | sed -r 's/.*\(yocto:project:reference:distro\):([0-9]+(\.[0-9]+)+?):\(.*\)$/yoctoproject:yocto:\1/')"
   # Buildroot 2022.01.01
   VERSION_IDENTIFIER="$(echo "$VERSION_IDENTIFIER" | sed -r 's/buildroot\ ([0-9]+(\.[0-9]+)+?)/buildroot:\1/')"
   VERSION_IDENTIFIER="${VERSION_IDENTIFIER// /:}"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature - further unblob integration

* **What is the current behavior?** (You can also link to an open issue here)

If binwalk fails and unblob is able to extract a firmware the unblob results are not used

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

If binwalk fails and unblob is able to extract the firmware the unblob results are used for further analysis

![image](https://user-images.githubusercontent.com/497520/205489595-1660532c-63cb-445c-a198-b9821b406958.png)

Closes https://github.com/e-m-b-a/emba/issues/392
