### PR TITLE
Modified the distribution check to accept operating systems like Popthat are ubuntu/debian based and mention it differently in the /etc/os-release file

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -145,7 +145,7 @@ if grep -q -i wsl /proc/version; then
 fi
 
 # distribution check
-if ! grep -q "ID_LIKE=debian" /etc/os-release 2>/dev/null ; then
+if ! grep -q "ID_LIKE=" /etc/os-release | grep -q "ubuntu\|debian" /etc/os-release 2>/dev/null ; then
   echo -e "\\n""$RED""EMBA only supports debian based distributions!""$NC\\n"
   print_help
   exit 1


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Modified the distribution check to accept operating systems like Popthat are ubuntu/debian based and mention it differently in the /etc/os-release file


* **What is the current behavior?** (You can also link to an open issue here)
installer will fail on pop_os


* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**
Installer will work on pop_os while still supporting the old scenario


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
