### PR TITLE
deprecated -l option

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -85,8 +85,6 @@ echo ""
 if [ "$#" -ne 1 ]; then
   echo -e "$RED""$BOLD""Invalid number of arguments""$NC"
   echo -e "\n\n------------------------------------------------------------------"
-  echo -e "Probably you would check all packets we are going to install with:"
-  echo -e "$CYAN""     sudo ./installer.sh -l""$NC"
   echo -e "If you are going to install EMBA in default mode you can use:"
   echo -e "$CYAN""     sudo ./installer.sh -d""$NC"
   echo -e "------------------------------------------------------------------\n\n"
@@ -121,7 +119,7 @@ while getopts cCdDFhlr OPT ; do
       export LIST_DEP=1
       export CVE_SEARCH=0
       export DOCKER_SETUP=0
-      echo -e "$GREEN""$BOLD""List all dependecies""$NC"
+      echo -e "$GREEN""$BOLD""List all dependecies (Warning: deprected feature)""$NC"
       ;;
     r)
       export REMOVE=1
@@ -134,6 +132,11 @@ while getopts cCdDFhlr OPT ; do
       ;;
   esac
 done
+
+if [[ "$LIST_DEP" -eq 1 ]]; then
+  echo -e "\n${ORANGE}WARNING: This feature is deprecated and not maintained anymore.$NC"
+  read -p "If you know what you are doing you can press any key to continue ..." -n1 -s -r
+fi
 
 # WSL support - currently experimental!
 if grep -q -i wsl /proc/version; then

--- a/installer.sh
+++ b/installer.sh
@@ -119,7 +119,7 @@ while getopts cCdDFhlr OPT ; do
       export LIST_DEP=1
       export CVE_SEARCH=0
       export DOCKER_SETUP=0
-      echo -e "$GREEN""$BOLD""List all dependecies (Warning: deprected feature)""$NC"
+      echo -e "$GREEN""$BOLD""List all dependecies (Warning: deprecated feature)""$NC"
       ;;
     r)
       export REMOVE=1

--- a/installer/helpers.sh
+++ b/installer/helpers.sh
@@ -23,7 +23,7 @@ print_help()
   echo -e "$CYAN""-F""$NC""         Developer installation (for running on your host in developer mode)"
   echo -e "$CYAN""-D""$NC""         Only used via docker-compose for building EMBA docker container"
   echo -e "$CYAN""-h""$NC""         Print this help message"
-  echo -e "$CYAN""-l""$NC""         List all dependencies of EMBA"
+  echo -e "$CYAN""-l""$NC""         List all dependencies of EMBA (deprecated)"
   echo -e "$CYAN""-r""$NC""         Remove a default installation of EMBA"
   echo
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Depredated feature

* **What is the current behavior?** (You can also link to an open issue here)

Installer -l is not maintained anymore

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

prints warning - closes https://github.com/e-m-b-a/emba/issues/474

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No, but the installer should be redesigned in the future (see also https://github.com/e-m-b-a/emba/issues/307 and https://github.com/e-m-b-a/emba/issues/310). During this we should also improve the list mode.
