### PR TITLE
L10 module improvements

### DIFF
--- a/helpers/fix_bins_lnk_emulation.sh
+++ b/helpers/fix_bins_lnk_emulation.sh
@@ -1,0 +1,70 @@
+#!/bin/bash -p
+
+# EMBA - EMBEDDED LINUX ANALYZER
+#
+# Copyright 2020-2023 Siemens Energy AG
+#
+# EMBA comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
+# welcome to redistribute it under the terms of the GNU General Public License.
+# See LICENSE file for usage of this software.
+#
+# EMBA is licensed under GPLv3
+#
+# Author(s): Michael Messner
+
+# Description:  Walk through a root directory and fix ELF permissions. Additionally
+#               this script also tries to fix sym links which are regularly broken
+
+BUSYBOX="/busybox"
+
+ROOT_DIR="${1:-}"
+if ! [[ -d "${ROOT_DIR}" ]]; then
+  echo "[-] No valid root directory provided - Fix links and bin permissions failed"
+  exit
+fi
+
+cp "$(command -v busybox)" "$ROOT_DIR"
+chmod +x "$ROOT_DIR"/busybox
+
+echo "[*] Identifying possible ELF files"
+mapfile -t POSSIBLE_ELFS < <(find "$ROOT_DIR" -type f -exec file {} \; | grep ELF | cut -d: -f1)
+
+for POSSIBLE_ELF in "${POSSIBLE_ELFS[@]}"; do
+  echo "[*] Processing ELF $(basename "$POSSIBLE_ELF") - chmod privileges"
+  chmod +x "$POSSIBLE_ELF"
+done
+
+HOME_DIR="$(pwd)"
+if [[ -d "$ROOT_DIR" ]]; then
+  cd "$ROOT_DIR" || exit 1
+else
+  exit 1
+fi
+
+echo ""
+echo "[*] Identifying possible symlinks"
+mapfile -t POSSIBLE_DEAD_SYMLNKS < <(find "." -type f -exec file {} \; | grep data | cut -d: -f1)
+
+for POSSIBLE_DEAD_SYMLNK in "${POSSIBLE_DEAD_SYMLNKS[@]}"; do
+  if [[ "$(strings "$POSSIBLE_DEAD_SYMLNK" | wc -l)" -eq 0 ]] || [[ "$(strings "$POSSIBLE_DEAD_SYMLNK" | wc -l)" -gt 1 ]]; then
+    continue
+  fi
+
+  TMP_LNK_ORIG=$(strings "$POSSIBLE_DEAD_SYMLNK")
+  TMP_LNK=${TMP_LNK_ORIG/\.\.\//}
+  POSSIBLE_SYMLNK_NAME=${POSSIBLE_DEAD_SYMLNK/\./}
+
+  mapfile -t POSSIBLE_MATCHES < <(find "." -wholename "*$TMP_LNK")
+  for MATCH in "${POSSIBLE_MATCHES[@]}"; do
+    if [[ "$MATCH" == "./busybox" ]]; then
+      continue
+    fi
+    MATCH=${MATCH/\./}
+    echo -e "[*] Symlink file $POSSIBLE_SYMLNK_NAME - $MATCH"
+    chroot . "$BUSYBOX" rm "$POSSIBLE_DEAD_SYMLNK"
+    chroot . "$BUSYBOX" ln -s "$MATCH" "$POSSIBLE_SYMLNK_NAME"
+  done
+done
+
+cd "$HOME_DIR" || exit 1
+rm "$ROOT_DIR"/busybox

--- a/modules/L10_system_emulation.sh
+++ b/modules/L10_system_emulation.sh
@@ -258,6 +258,11 @@ create_emulation_filesystem() {
     print_output "[*] Copy extracted root filesystem to new QEMU image"
     cp -prf "$ROOT_PATH"/* "$MNT_POINT"/ || true
 
+    if [[ -f "$HELP_DIR"/fix_bins_lnk_emulation.sh ]]; then
+      print_output "[*] Starting link fixing helper ..."
+      "$HELP_DIR"/fix_bins_lnk_emulation.sh "$MNT_POINT"
+    fi
+
     # ensure that the needed permissions for exec files are set correctly
     # This is needed at some firmwares have corrupted permissions on ELF or sh files
     print_output "[*] Multiple firmwares have broken script and ELF permissions - We fix them now"

--- a/modules/P70_unblob.sh
+++ b/modules/P70_unblob.sh
@@ -134,7 +134,7 @@ unblobber() {
     mkdir -p "$OUTPUT_DIR_UNBLOB"
   fi
 
-  timeout --preserve-status --signal SIGINT 300 "$UNBLOB_BIN" -v -e "$OUTPUT_DIR_UNBLOB" "$FIRMWARE_PATH_" | tee -a "$LOG_FILE" || true
+  timeout --preserve-status --signal SIGINT 300 "$UNBLOB_BIN" -v -k -e "$OUTPUT_DIR_UNBLOB" "$FIRMWARE_PATH_" | tee -a "$LOG_FILE" || true
 
   print_ln
 }

--- a/modules/P70_unblob.sh
+++ b/modules/P70_unblob.sh
@@ -134,7 +134,7 @@ unblobber() {
     mkdir -p "$OUTPUT_DIR_UNBLOB"
   fi
 
-  timeout --preserve-status --signal SIGINT 300 "$UNBLOB_BIN" -e "$OUTPUT_DIR_UNBLOB" "$FIRMWARE_PATH_" | tee -a "$LOG_FILE" || true
+  timeout --preserve-status --signal SIGINT 300 "$UNBLOB_BIN" -v -e "$OUTPUT_DIR_UNBLOB" "$FIRMWARE_PATH_" | tee -a "$LOG_FILE" || true
 
   print_ln
 }

--- a/modules/S115_usermode_emulator.sh
+++ b/modules/S115_usermode_emulator.sh
@@ -80,6 +80,10 @@ S115_usermode_emulator() {
       print_ln
       NEG_LOG=1
       print_output "[*] Detected root path: $ORANGE$R_PATH$NC"
+      if [[ -f "$HELP_DIR"/fix_bins_lnk_emulation.sh ]]; then
+        print_output "[*] Starting link fixing helper ..."
+        "$HELP_DIR"/fix_bins_lnk_emulation.sh "$R_PATH"
+      fi
       # MD5_DONE_INT is the array of all MD5 checksums for all root paths -> this is needed to ensure that we do not test bins twice
       MD5_DONE_INT=()
       BIN_CNT=0


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

symlinks are not re-generated for s115 and l10
identification of already up and running emulations via services not integrated

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

better symlink recovery
check services for init/rdinit switch
