### PR TITLE
Updated installer.sh for "ubuntu debian" /etc/os-release and new version string

### DIFF
--- a/config/bin_version_strings.cfg
+++ b/config/bin_version_strings.cfg
@@ -417,6 +417,7 @@ fsck.fat;;gplv3;"^fsck\.fat\ [0-9]+(\.[0-9]+)+?";"sed -r 's/fsck\.fat\ ([0-9]+(\
 fatlabel;;gplv3;"^fatlabel\ [0-9]+(\.[0-9]+)+?";"sed -r 's/fatlabel\ ([0-9]+(\.[0-9]+)+?).*/dosfstools:\1/'";
 mklost_plus_found;;unknown;"^mklost\+found\ [0-9]+(\.[0-9]+)+?\ \(.*\)$";"sed -r 's/mklost\+found\ ([0-9]+(\.[0-9]+)+?).*/e2fsprogs:\1/'";
 mkntfs;;gplv2;"mkntfs\ [0-9]+(\.[0-9]+)+?";"sed -r 's/mkntfs\ ([0-9]+(\.[0-9]+)+?).*/ntfsprogs:\1/'";
+mkntfs;;gplv2;"^mkntfs\ v[0-9]+(\.[0-9]+)+?";"sed -r 's/mkntfs\ ([0-9]+(\.[0-9]+)+?).*/ntfsprogs:\1/'";
 mkpasswd;;unknown;"mkpasswd\ [0-9](\.[0-9]+)+?";"sed -r 's/mkpasswd\ ([0-9](\.[0-9]+)+?).*/mkpasswd:\1/'";
 mkreiserfs;;unknown;"mkreiserfs\ [0-9](\.[0-9]+)+?$";"sed -r 's/mkreiserfs\ ([0-9](\.[0-9]+)+?)$/reiserfsck:\1/'";
 modem;strict;unknown;"Version\ [0-9]\.[0-9]+\.[0-9]+";"sed -r 's/Version\ ([0-9](\.[0-9]+)+?)$/modem:\1/'";

--- a/config/bin_version_strings.cfg
+++ b/config/bin_version_strings.cfg
@@ -416,8 +416,7 @@ mkdosfs;;gplv3;"^mkdosfs\ [0-9](\.[0-9]+)+?\ \([0-9]+\ .*\ [0-9]+\)$";"sed -r 's
 fsck.fat;;gplv3;"^fsck\.fat\ [0-9]+(\.[0-9]+)+?";"sed -r 's/fsck\.fat\ ([0-9]+(\.[0-9]+)+?).*/dosfstools:\1/'";
 fatlabel;;gplv3;"^fatlabel\ [0-9]+(\.[0-9]+)+?";"sed -r 's/fatlabel\ ([0-9]+(\.[0-9]+)+?).*/dosfstools:\1/'";
 mklost_plus_found;;unknown;"^mklost\+found\ [0-9]+(\.[0-9]+)+?\ \(.*\)$";"sed -r 's/mklost\+found\ ([0-9]+(\.[0-9]+)+?).*/e2fsprogs:\1/'";
-mkntfs;;gplv2;"mkntfs\ [0-9]+(\.[0-9]+)+?";"sed -r 's/mkntfs\ ([0-9]+(\.[0-9]+)+?).*/ntfsprogs:\1/'";
-mkntfs;;gplv2;"^mkntfs\ v[0-9]+(\.[0-9]+)+?";"sed -r 's/mkntfs\ ([0-9]+(\.[0-9]+)+?).*/ntfsprogs:\1/'";
+mkntfs;;gplv2;"mkntfs\ (v)?[0-9]+(\.[0-9]+)+?";"sed -r 's/mkntfs\ v?([0-9]+(\.[0-9]+)+?).*/ntfsprogs:\1/'";
 mkpasswd;;unknown;"mkpasswd\ [0-9](\.[0-9]+)+?";"sed -r 's/mkpasswd\ ([0-9](\.[0-9]+)+?).*/mkpasswd:\1/'";
 mkreiserfs;;unknown;"mkreiserfs\ [0-9](\.[0-9]+)+?$";"sed -r 's/mkreiserfs\ ([0-9](\.[0-9]+)+?)$/reiserfsck:\1/'";
 modem;strict;unknown;"Version\ [0-9]\.[0-9]+\.[0-9]+";"sed -r 's/Version\ ([0-9](\.[0-9]+)+?)$/modem:\1/'";

--- a/installer.sh
+++ b/installer.sh
@@ -158,7 +158,7 @@ if grep -q -i wsl /proc/version; then
 fi
 
 # distribution check
-if ! grep -q "ID_LIKE="\"?"(ubuntu )"?debian"\"?$" /etc/os-release 2>/dev/null ; then
+if ! grep -Eq "ID_LIKE="\"?"(ubuntu )"?debian"\"?$" /etc/os-release 2>/dev/null ; then
   echo -e "\\n""$RED""EMBA only supports debian based distributions!""$NC\\n"
   print_help
   exit 1

--- a/installer.sh
+++ b/installer.sh
@@ -158,7 +158,7 @@ if grep -q -i wsl /proc/version; then
 fi
 
 # distribution check
-if ! grep -Eq "ID_LIKE="\"?"(ubuntu )"?debian"\"?$" /etc/os-release 2>/dev/null ; then
+if ! grep -Eq "ID_LIKE=(\")?(ubuntu)?( )?(debian)?" /etc/os-release 2>/dev/null ; then
   echo -e "\\n""$RED""EMBA only supports debian based distributions!""$NC\\n"
   print_help
   exit 1

--- a/installer.sh
+++ b/installer.sh
@@ -158,7 +158,7 @@ if grep -q -i wsl /proc/version; then
 fi
 
 # distribution check
-if ! grep -q "ID_LIKE=debian" /etc/os-release 2>/dev/null ; then
+if ! grep -q "ID_LIKE="\"?"(ubuntu )"?debian"\"?$" /etc/os-release 2>/dev/null ; then
   echo -e "\\n""$RED""EMBA only supports debian based distributions!""$NC\\n"
   print_help
   exit 1


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
The installer can now be executed in ubuntu based distros that have "ubuntu debian" or debian as ID_LIKE in /etc/os-release.
New version string added

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
