### PR TITLE
Freetz extraction module deprecated

### DIFF
--- a/modules/P12_avm_freetz_ng_extract.sh
+++ b/modules/P12_avm_freetz_ng_extract.sh
@@ -54,6 +54,13 @@ avm_extractor() {
   export FRITZ_FILE=0
   export FRITZ_VERSION=""
 
+  local MODULE_DISABLED=1
+
+  if [[ "$MODULE_DISABLED" -eq 1 ]]; then
+    print_output "[*] Module ${FUNCNAME[0]} is deprecated and will be removed in the future"
+    return
+  fi
+
   sub_module_title "AVM freetz-ng firmware extractor"
 
   # read only filesystem bypass:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature -> Unblob replacement of P12

* **What is the current behavior?** (You can also link to an open issue here)

Freetz-NG integration in combination with binwalk

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

Only unblob for AVM firmware
