### PR TITLE
Remove warning apt-key is deprecated

### DIFF
--- a/installer/IF20_cve_search.sh
+++ b/installer/IF20_cve_search.sh
@@ -115,8 +115,8 @@ IF20_cve_search() {
             echo -e "\\n""$MAGENTA""cve-search database not ready.""$NC"
         fi
         if [[ "$CVE_INST" -eq 1 ]]; then
-          wget --no-check-certificate -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | sudo apt-key add -
-          echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.4.list
+          wget --no-check-certificate -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/mongodb.gpg > /dev/null
+          echo "deb [ signed-by=/etc/apt/trusted.gpg.d/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.4.list
           apt-get update -y
           print_tool_info "mongodb-org" 1
           apt-get install mongodb-org -y


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Removes the warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)). 


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
