### PR TITLE
Improved default profile handling / running modules script

### DIFF
--- a/helpers/running_modules.sh
+++ b/helpers/running_modules.sh
@@ -1,0 +1,44 @@
+#!/bin/bash -p
+# see: https://developer.apple.com/library/archive/documentation/OpenSource/Conceptual/ShellScripting/ShellScriptSecurity/ShellScriptSecurity.html#//apple_ref/doc/uid/TP40004268-CH8-SW29
+
+# EMBA - EMBEDDED LINUX ANALYZER
+#
+# Copyright 2020-2023 Siemens Energy AG
+#
+# EMBA comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
+# welcome to redistribute it under the terms of the GNU General Public License.
+# See LICENSE file for usage of this software.
+#
+# EMBA is licensed under GPLv3
+#
+# Author(s): Michael Messner
+
+# Description:  EMBA helper script to identify currently running EMBA modules
+#               start it with "watch". E.g., 
+#               watch -c ./helpers/running_modules.sh ~/firmware-stuff/emba_logs_dir300_new_bins
+
+
+export GREEN="\033[0;32m"
+export ORANGE="\033[0;33m"
+export NC="\033[0m"  # no color
+
+if [[ $# -eq 0 ]]; then
+  echo -e "\\n""${ORANGE}""In order to be able to use EMBAbite, you have to specify at least an EMBA firmware log directory${NC}"
+  exit 1
+fi
+
+EMBA_LOG_DIR="${1:-}"
+EMBA_LOG_FILE="${EMBA_LOG_DIR}""/emba.log"
+if ! [[ -f "${EMBA_LOG_FILE}" ]]; then
+  echo -e "\\n""${ORANGE}""No valid EMBA firmware log directory found.${NC}"
+  exit 1
+fi
+
+
+mapfile -t STARTED_EMBA_PROCESSES < <(grep starting "${EMBA_LOG_FILE}" | awk '{print $9}'|| true)
+
+for EMBA_STARTED_PROC in "${STARTED_EMBA_PROCESSES[@]}"; do
+  if ! grep -q "${EMBA_STARTED_PROC}"" finished" "${EMBA_LOG_FILE}"; then
+    echo -e "[*] EMBA module ${GREEN}${EMBA_STARTED_PROC}${NC} currently running"
+  fi
+done

--- a/helpers/running_modules.sh
+++ b/helpers/running_modules.sh
@@ -29,11 +29,11 @@ fi
 
 EMBA_LOG_DIR="${1:-}"
 EMBA_LOG_FILE="${EMBA_LOG_DIR}""/emba.log"
+
 if ! [[ -f "${EMBA_LOG_FILE}" ]]; then
   echo -e "\\n""${ORANGE}""No valid EMBA firmware log directory found.${NC}"
   exit 1
 fi
-
 
 mapfile -t STARTED_EMBA_PROCESSES < <(grep starting "${EMBA_LOG_FILE}" | awk '{print $9}'|| true)
 

--- a/helpers/running_modules.sh
+++ b/helpers/running_modules.sh
@@ -23,7 +23,7 @@ export ORANGE="\033[0;33m"
 export NC="\033[0m"  # no color
 
 if [[ $# -eq 0 ]]; then
-  echo -e "\\n""${ORANGE}""In order to be able to use EMBAbite, you have to specify at least an EMBA firmware log directory${NC}"
+  echo -e "\\n""${ORANGE}""In order to be able to use this script, you have to specify an EMBA firmware log directory${NC}"
   exit 1
 fi
 

--- a/scan-profiles/default-scan-emulation.emba
+++ b/scan-profiles/default-scan-emulation.emba
@@ -1,7 +1,7 @@
 # EMBA - EMBEDDED LINUX ANALYZER
 #
-# Copyright 2020-2022 Siemens Energy AG
-# Copyright 2020-2022 Siemens AG
+# Copyright 2020-2023 Siemens Energy AG
+# Copyright 2020-2023 Siemens AG
 #
 # EMBA comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
 # welcome to redistribute it under the terms of the GNU General Public License.

--- a/scan-profiles/default-scan-long.emba
+++ b/scan-profiles/default-scan-long.emba
@@ -1,0 +1,36 @@
+# EMBA - EMBEDDED LINUX ANALYZER
+#
+# Copyright 2020-2023 Siemens Energy AG
+# Copyright 2020-2023 Siemens AG
+#
+# EMBA comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
+# welcome to redistribute it under the terms of the GNU General Public License.
+# See LICENSE file for usage of this software.
+#
+# EMBA is licensed under GPLv3
+#
+# Author(s): Michael Messner, Pascal Eckmann
+#
+# Description: This is a default EMBA profile. You can Use it as a template for your own profiles
+#              or start emba with "-p default-scan.emba" to use it
+
+export FORMAT_LOG=1
+export THREADED=1
+export SHORT_PATH=1
+export HTML=1
+export QEMULATION=1
+
+# we output the profile only at the beginning - outside the docker environment
+if [[ $IN_DOCKER -ne 1 ]] ; then
+  print_output "$(indent "$(orange "Adds ANSI color codes to log")")" "no_log"
+  print_output "$(indent "$(orange "Activate multi threading (destroys regular console output)")")" "no_log"
+  print_output "$(indent "$(orange "Prints only relative paths")")" "no_log"
+  print_output "$(indent "$(orange "Activates web report creation in log path")")" "no_log"
+  if [[ "$USE_DOCKER" -ne 1 ]]; then
+    print_output "$(indent "$(orange "Enables automated qemu emulation tests (WARNING this module could harm your host!)")")" "no_log"
+  else
+    print_output "$(indent "$(orange "Enables automated qemu emulation tests")")" "no_log"
+  fi
+  print_output "$(indent "$(orange "Runs EMBA in docker container")")" "no_log"
+  export USE_DOCKER=1
+fi

--- a/scan-profiles/default-scan.emba
+++ b/scan-profiles/default-scan.emba
@@ -19,6 +19,7 @@ export THREADED=1
 export SHORT_PATH=1
 export HTML=1
 export QEMULATION=1
+export MODULE_BLACKLIST=( "S99_grepit" "S110_yara_check" )
 
 # we output the profile only at the beginning - outside the docker environment
 if [[ $IN_DOCKER -ne 1 ]] ; then
@@ -32,5 +33,9 @@ if [[ $IN_DOCKER -ne 1 ]] ; then
     print_output "$(indent "$(orange "Enables automated qemu emulation tests")")" "no_log"
   fi
   print_output "$(indent "$(orange "Runs EMBA in docker container")")" "no_log"
+  print_output "$(indent "$(orange "Disable EMBA module via profile")")" "no_log"
+  for MODULE_ in "${MODULE_BLACKLIST[@]}"; do
+    print_output "$(indent "$(orange "Blacklisted module: $MODULE_")")" "no_log"
+  done
   export USE_DOCKER=1
 fi

--- a/scan-profiles/default-scan.emba
+++ b/scan-profiles/default-scan.emba
@@ -1,7 +1,7 @@
 # EMBA - EMBEDDED LINUX ANALYZER
 #
-# Copyright 2020-2022 Siemens Energy AG
-# Copyright 2020-2022 Siemens AG
+# Copyright 2020-2023 Siemens Energy AG
+# Copyright 2020-2023 Siemens AG
 #
 # EMBA comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
 # welcome to redistribute it under the terms of the GNU General Public License.

--- a/scan-profiles/full-scan.emba
+++ b/scan-profiles/full-scan.emba
@@ -1,7 +1,7 @@
 # EMBA - EMBEDDED LINUX ANALYZER
 #
-# Copyright 2020-2022 Siemens Energy AG
-# Copyright 2020-2022 Siemens AG
+# Copyright 2020-2023 Siemens Energy AG
+# Copyright 2020-2023 Siemens AG
 #
 # EMBA comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
 # welcome to redistribute it under the terms of the GNU General Public License.
@@ -21,6 +21,7 @@ export HTML=1
 export CWE_CHECKER=1
 export QEMULATION=1
 export FULL_EMULATION=1
+
 # we output the profile only at the beginning - outside the docker environment
 if [[ $IN_DOCKER -ne 1 ]] ; then
   print_output "$(indent "$(orange "Adds ANSI color codes to log")")" "no_log"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

Default profile has some long running modules enabled (S110, s99)
It is hard to find the running modules during a long EMBA scan
s22 not using semgrep

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

default profile now disables these modules and created a new default-long profile
New helper script for finding currently running EMBA modules quite easy
![image](https://user-images.githubusercontent.com/497520/230727373-04f975d3-5586-4ba3-92ea-726e1dcbfa06.png)
Start this script with "watch -c" in a second terminal and you can see which modules are currently running.
semgrep now also for php script analysis
![image](https://user-images.githubusercontent.com/497520/230785453-7d1a6c6e-e5c5-4a2c-b2bb-f7a1f5b29182.png)

* **Other information**:

Thanks to [Nate](https://github.com/n0x08) (https://twitter.com/n0x08) for the feedback