### PR TITLE
Avoiding /proc and /sys paths (-xdev) in symlink script and check for missing symlinks in s115

### DIFF
--- a/helpers/fix_bins_lnk_emulation.sh
+++ b/helpers/fix_bins_lnk_emulation.sh
@@ -44,9 +44,12 @@ fi
 
 echo ""
 echo "[*] Identifying possible dead symlinks"
-mapfile -t POSSIBLE_DEAD_SYMLNKS < <(find "." -type f) # -exec file {} \; | grep "data\|ASCII\ text" | cut -d: -f1)
+mapfile -t POSSIBLE_DEAD_SYMLNKS < <(find "." -xdev -type f) # -exec file {} \; | grep "data\|ASCII\ text" | cut -d: -f1)
 
 for POSSIBLE_DEAD_SYMLNK in "${POSSIBLE_DEAD_SYMLNKS[@]}"; do
+  if [[ "$POSSIBLE_DEAD_SYMLNK" == *"/proc/"* ]]; then
+    continue
+  fi
   DIR_ORIG_FILE=""
   if [[ "$(strings "$POSSIBLE_DEAD_SYMLNK" | wc -l)" -gt 1 ]]; then
     continue

--- a/modules/S115_usermode_emulator.sh
+++ b/modules/S115_usermode_emulator.sh
@@ -80,8 +80,8 @@ S115_usermode_emulator() {
       print_ln
       NEG_LOG=1
       print_output "[*] Detected root path: $ORANGE$R_PATH$NC"
-      if [[ -f "$HELP_DIR"/fix_bins_lnk_emulation.sh ]]; then
-        print_output "[*] Starting link fixing helper ..."
+      if [[ -f "$HELP_DIR"/fix_bins_lnk_emulation.sh ]] && [[ $(find "$R_PATH" -type l | wc -l) -lt 10 ]]; then
+        print_output "[*] No symlinks found in firmware ... Starting link fixing helper ..."
         "$HELP_DIR"/fix_bins_lnk_emulation.sh "$R_PATH"
       fi
       # MD5_DONE_INT is the array of all MD5 checksums for all root paths -> this is needed to ensure that we do not test bins twice


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
