### PR TITLE
update ubuntu libssl source

### DIFF
--- a/installer/ID1_ubuntu_os.sh
+++ b/installer/ID1_ubuntu_os.sh
@@ -46,12 +46,12 @@ ID1_ubuntu_os() {
         # libssl1.1 missing
         echo -e "\\n""$BOLD""Installing libssl1.1 for mongodb!""$NC"
         # echo "deb http://security.ubuntu.com/ubuntu impish-security main" | tee /etc/apt/sources.list.d/impish-security.list
-        wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.1.1-1ubuntu2.1~18.04.21_amd64.deb -O external/libssl-dev_1.1.1-1ubuntu2.1~18.04.21_amd64.deb
-        wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1-1ubuntu2.1~18.04.21_amd64.deb -O external/libssl1.1_1.1.1-1ubuntu2.1~18.04.21_amd64.deb
-        dpkg -i external/libssl1.1_1.1.1-1ubuntu2.1~18.04.21_amd64.deb
-        dpkg -i external/libssl-dev_1.1.1-1ubuntu2.1~18.04.21_amd64.deb
-        rm external/libssl1.1_1.1.1-1ubuntu2.1~18.04.21_amd64.deb
-        rm external/libssl-dev_1.1.1-1ubuntu2.1~18.04.21_amd64.deb
+        wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl-dev_1.1.1-1ubuntu2.1~18.04.22_amd64.deb -O external/libssl-dev_1.1.1-1ubuntu2.1~18.04.22_amd64.deb
+        wget http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1-1ubuntu2.1~18.04.22_amd64.deb -O external/libssl1.1_1.1.1-1ubuntu2.1~18.04.22_amd64.deb
+        dpkg -i external/libssl1.1_1.1.1-1ubuntu2.1~18.04.22_amd64.deb
+        dpkg -i external/libssl-dev_1.1.1-1ubuntu2.1~18.04.22_amd64.deb
+        rm external/libssl1.1_1.1.1-1ubuntu2.1~18.04.22_amd64.deb
+        rm external/libssl-dev_1.1.1-1ubuntu2.1~18.04.22_amd64.deb
     fi
 
     if [[ "$WSL" -eq 1 ]]; then


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
---
quick fix for libssl source on ubuntu 22.04
for the mongodb stuff

**What is the current behavior?** (You can also link to an open issue here)
---
installer error on ubuntu 22.04

**What is the new behavior (if this is a feature change)? If possible add a screenshot.**
---
✔️ 

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
---
No
