### PR TITLE
Debian repos - https only for Kali

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -256,8 +256,13 @@ if [[ $LIST_DEP -eq 0 ]] ; then
   fi
 
   echo -e "\\n""$ORANGE""Update package lists.""$NC"
-  sed -i 's/deb http:\/\//deb https:\/\//g' /etc/apt/sources.list
-  sed -i 's/deb-src http:\/\//deb-src https:\/\//g' /etc/apt/sources.list
+  # we only update Kali repos to https. This makes sense as multiple proxy environments are blocking "hacking" packages like Metasploit
+  # with https they usually do not inspect the traffic and so they do not block anything
+  # As we got reports on issues with Ubuntu we only change this for Kali - see here https://github.com/e-m-b-a/emba/issues/765
+  if grep -q "kali" /etc/debian_version 2>/dev/null ; then
+    sed -i 's/deb http:\/\//deb https:\/\//g' /etc/apt/sources.list
+    sed -i 's/deb-src http:\/\//deb-src https:\/\//g' /etc/apt/sources.list
+  fi
   apt-get -y update
 fi
 

--- a/installer/I01_default_apps.sh
+++ b/installer/I01_default_apps.sh
@@ -49,6 +49,9 @@ I01_default_apps(){
     print_tool_info "python3-pip" 1
     print_pip_info "requests"
 
+    # Ubuntu not installing ping - see https://github.com/e-m-b-a/embark/issues/151
+    print_tool_info "iputils-ping" 1
+
     # tools only available on Kali Linux:
     if [[ "$OTHER_OS" -eq 0 ]] && [[ "$UBUNTU_OS" -eq 0 ]]; then
       print_tool_info "metasploit-framework" 1


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Quick fix

* **What is the current behavior?** (You can also link to an open issue here)

see https://github.com/e-m-b-a/emba/issues/765
see https://github.com/e-m-b-a/embark/issues/151

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

Closes https://github.com/e-m-b-a/emba/issues/765
Closes https://github.com/e-m-b-a/embark/issues/151

This is not a beautiful fix. Nevertheless, I  think most users are not running into the problem that dpk downloads are blocked. It is more for building the EMBA container. 