### PR TITLE
fix gpt path

### DIFF
--- a/modules/Q02_openai_question.sh
+++ b/modules/Q02_openai_question.sh
@@ -98,6 +98,7 @@ ask_chatgpt() {
       # remove the '.'
       SCRIPT_PATH_TMP_="${SCRIPT_PATH_TMP_:1}"
       # remove the LOG_DIR
+      # shellcheck disable=SC2001
       SCRIPT_PATH_TMP_="$(echo "${SCRIPT_PATH_TMP_}" | sed 's#'"${LOG_DIR}"'##')"
       print_output "[*] Stripped path $SCRIPT_PATH_TMP_" "no_log"
     fi

--- a/modules/Q02_openai_question.sh
+++ b/modules/Q02_openai_question.sh
@@ -93,7 +93,16 @@ ask_chatgpt() {
     # in case we have nothing we are going to move on
     [[ -z "${SCRIPT_PATH_TMP_}" ]] && continue
     print_output "[*] Identification of ${ORANGE}${SCRIPT_PATH_TMP_} / ${GPT_INPUT_FILE_}${NC} inside ${ORANGE}${LOG_DIR}/firmware${NC}" "no_log"
-    SCRIPT_PATH_TMP_="$(find "${LOG_DIR}/firmware" -wholename "*${SCRIPT_PATH_TMP_}")"
+    if [[ "${SCRIPT_PATH_TMP_}" == ".""${LOG_DIR}"* ]]; then
+      print_output "[*] Warning: System path is not stripped with the root directory - we try to fix it now" "no_log"
+      # remove the '.'
+      SCRIPT_PATH_TMP_="${SCRIPT_PATH_TMP_:1}"
+      # remove the LOG_DIR
+      SCRIPT_PATH_TMP_="$(echo "${SCRIPT_PATH_TMP_}" | sed 's#'"${LOG_DIR}"'##')"
+      print_output "[*] Stripped path $SCRIPT_PATH_TMP_" "no_log"
+    fi
+    # dirty fix - Todo: use array in future
+    SCRIPT_PATH_TMP_="$(find "${LOG_DIR}/firmware" -wholename "*${SCRIPT_PATH_TMP_}" | head -1)"
 
     # in case we have nothing we are going to move on
     ! [[ -f "${SCRIPT_PATH_TMP_}" ]] && continue


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix
Thx @n0x08 for reporting this issue

* **What is the current behavior?** (You can also link to an open issue here)

If EMBA identifies multiple root paths the cut_path functions is currently not able to handle this. This results in not finding the files for Q02

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

remove the log dir to use the path for searching.

