### PR TITLE
Debian installer support

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -174,7 +174,7 @@ if grep -q -i wsl /proc/version; then
 fi
 
 # distribution check
-if ! grep -Eq "ID_LIKE=(\")?(ubuntu)?( )?(debian)?" /etc/os-release 2>/dev/null ; then
+if ! grep -Eq "ID(_LIKE)?=(\")?(ubuntu)?( )?(debian)?" /etc/os-release 2>/dev/null ; then
   echo -e "\\n""$RED""EMBA only supports debian based distributions!""$NC\\n"
   print_help
   exit 1


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

Installer failed hard on current Debian 12

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

Installer supports Debian 12

* **Other information**:

I needed to add /sbin to PATH. Probably this was only on my system but in case someone needs to adjust PATH
```
export PATH=$PATH:/sbin
```

**Info: We have not tested EMBA in depth on Debian. If someone has time please support with further testing.**