### PR TITLE
strict mode grep error

### DIFF
--- a/modules/P02_firmware_bin_file_check.sh
+++ b/modules/P02_firmware_bin_file_check.sh
@@ -272,7 +272,7 @@ fw_bin_detector() {
   # probably we need to take a deeper look to identify the gpg compressed firmware files better.
   # Currently this detection mechanism works quite good on the known firmware images
   if [[ "$DLINK_ENC_CHECK" =~ 00000000\ \ a3\ 01\  ]]; then
-    GPG_CHECK="$(gpg --list-packets "$FIRMWARE_PATH" | grep "compressed packet:")"
+    GPG_CHECK="$(gpg --list-packets "$FIRMWARE_PATH" | grep "compressed packet:" || true)"
     if [[ "$GPG_CHECK" == *"compressed packet: algo="* ]]; then
       print_output "[+] Identified GPG compressed firmware - using GPG extraction module"
       export GPG_COMPRESS=1


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
In strict mode the grep command won't fail anymore and break emba.


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
