### PR TITLE
fwhunt check entire firmware first

### DIFF
--- a/modules/S02_UEFI_FwHunt.sh
+++ b/modules/S02_UEFI_FwHunt.sh
@@ -32,7 +32,7 @@ S02_UEFI_FwHunt() {
   if [[ "${UEFI_VERIFIED}" -eq 1 ]] || { [[ "${RTOS}" -eq 1 ]] && [[ "${UEFI_DETECTED}" -eq 1 ]]; }; then
     print_output "[*] Starting FwHunter UEFI firmware vulnerability detection"      
     fwhunter "${FIRMWARE_PATH_BAK}"
-    if [[ $(grep -c "FwHunt rule" "${LOG_PATH_MODULE}""/fwhunt_scan_firmware.txt" ) -eq 0 ]]; then
+    if [[ $(grep -c "FwHunt rule" "${LOG_PATH_MODULE}""/fwhunt_scan_"* | cut -d: -f2 | awk '{ SUM += $1} END { print SUM }' || true) -eq 0 ]]; then
       for EXTRACTED_FILE in "${FILE_ARR_LIMITED[@]}"; do
         if [[ ${THREADED} -eq 1 ]]; then
           fwhunter "${EXTRACTED_FILE}" &

--- a/modules/S02_UEFI_FwHunt.sh
+++ b/modules/S02_UEFI_FwHunt.sh
@@ -31,7 +31,15 @@ S02_UEFI_FwHunt() {
 
   if [[ "${UEFI_VERIFIED}" -eq 1 ]] || { [[ "${RTOS}" -eq 1 ]] && [[ "${UEFI_DETECTED}" -eq 1 ]]; }; then
     print_output "[*] Starting FwHunter UEFI firmware vulnerability detection"
-    fwhunter "${FIRMWARE_PATH_BAK}"
+    if [[ ${THREADED} -eq 1 ]]; then
+      fwhunter "${FIRMWARE_PATH_BAK}" &
+      local TMP_PID="$!"
+      store_kill_pids "${TMP_PID}"
+      WAIT_PIDS_S02+=( "${TMP_PID}" )
+      max_pids_protection "${MAX_MOD_THREADS}" "${WAIT_PIDS_S02[@]}"
+    else
+      fwhunter "${FIRMWARE_PATH_BAK}"
+    fi
     if [[ $(grep -c "FwHunt rule" "${LOG_PATH_MODULE}""/fwhunt_scan_"*) -eq 0 ]]; then
       for EXTRACTED_FILE in "${FILE_ARR_LIMITED[@]}"; do
         if [[ ${THREADED} -eq 1 ]]; then

--- a/modules/S02_UEFI_FwHunt.sh
+++ b/modules/S02_UEFI_FwHunt.sh
@@ -10,7 +10,7 @@
 #
 # EMBA is licensed under GPLv3
 #
-# Author(s): Michael Messner
+# Author(s): Michael Messner, Endri Hoxha
 # Credits:   Binarly for support
 
 # Description:  Uses FwHunt for identification of vulnerabilities in possible UEFI firmware

--- a/modules/S02_UEFI_FwHunt.sh
+++ b/modules/S02_UEFI_FwHunt.sh
@@ -30,17 +30,9 @@ S02_UEFI_FwHunt() {
   local EXTRACTED_FILE=""
 
   if [[ "${UEFI_VERIFIED}" -eq 1 ]] || { [[ "${RTOS}" -eq 1 ]] && [[ "${UEFI_DETECTED}" -eq 1 ]]; }; then
-    print_output "[*] Starting FwHunter UEFI firmware vulnerability detection"
-    if [[ ${THREADED} -eq 1 ]]; then
-      fwhunter "${FIRMWARE_PATH_BAK}" &
-      local TMP_PID="$!"
-      store_kill_pids "${TMP_PID}"
-      WAIT_PIDS_S02+=( "${TMP_PID}" )
-      max_pids_protection "${MAX_MOD_THREADS}" "${WAIT_PIDS_S02[@]}"
-    else
-      fwhunter "${FIRMWARE_PATH_BAK}"
-    fi
-    if [[ $(grep -c "FwHunt rule" "${LOG_PATH_MODULE}""/fwhunt_scan_"*) -eq 0 ]]; then
+    print_output "[*] Starting FwHunter UEFI firmware vulnerability detection"      
+    fwhunter "${FIRMWARE_PATH_BAK}"
+    if [[ $(grep -c "FwHunt rule" "${LOG_PATH_MODULE}""/fwhunt_scan_firmware.txt" ) -eq 0 ]]; then
       for EXTRACTED_FILE in "${FILE_ARR_LIMITED[@]}"; do
         if [[ ${THREADED} -eq 1 ]]; then
           fwhunter "${EXTRACTED_FILE}" &

--- a/modules/S02_UEFI_FwHunt.sh
+++ b/modules/S02_UEFI_FwHunt.sh
@@ -10,7 +10,7 @@
 #
 # EMBA is licensed under GPLv3
 #
-# Author(s): Michael Messner, Endri Hoxha
+# Author(s): Michael Messner
 # Credits:   Binarly for support
 
 # Description:  Uses FwHunt for identification of vulnerabilities in possible UEFI firmware
@@ -30,7 +30,7 @@ S02_UEFI_FwHunt() {
   local EXTRACTED_FILE=""
 
   if [[ "${UEFI_VERIFIED}" -eq 1 ]] || { [[ "${RTOS}" -eq 1 ]] && [[ "${UEFI_DETECTED}" -eq 1 ]]; }; then
-    print_output "[*] Starting FwHunter UEFI firmware vulnerability detection"      
+    print_output "[*] Starting FwHunter UEFI firmware vulnerability detection"
     fwhunter "${FIRMWARE_PATH_BAK}"
     if [[ $(grep -c "FwHunt rule" "${LOG_PATH_MODULE}""/fwhunt_scan_"* | cut -d: -f2 | awk '{ SUM += $1} END { print SUM }' || true) -eq 0 ]]; then
       for EXTRACTED_FILE in "${FILE_ARR_LIMITED[@]}"; do

--- a/modules/S02_UEFI_FwHunt.sh
+++ b/modules/S02_UEFI_FwHunt.sh
@@ -31,17 +31,20 @@ S02_UEFI_FwHunt() {
 
   if [[ "${UEFI_VERIFIED}" -eq 1 ]] || { [[ "${RTOS}" -eq 1 ]] && [[ "${UEFI_DETECTED}" -eq 1 ]]; }; then
     print_output "[*] Starting FwHunter UEFI firmware vulnerability detection"
-    for EXTRACTED_FILE in "${FILE_ARR_LIMITED[@]}"; do
-      if [[ ${THREADED} -eq 1 ]]; then
-        fwhunter "${EXTRACTED_FILE}" &
-        local TMP_PID="$!"
-        store_kill_pids "${TMP_PID}"
-        WAIT_PIDS_S02+=( "${TMP_PID}" )
-        max_pids_protection "${MAX_MOD_THREADS}" "${WAIT_PIDS_S02[@]}"
-      else
-        fwhunter "${EXTRACTED_FILE}"
-      fi
-    done
+    fwhunter "${FIRMWARE_PATH_BAK}"
+    if [[ $(grep -c "FwHunt rule" "${LOG_PATH_MODULE}""/fwhunt_scan_"*) -eq 0 ]]; then
+      for EXTRACTED_FILE in "${FILE_ARR_LIMITED[@]}"; do
+        if [[ ${THREADED} -eq 1 ]]; then
+          fwhunter "${EXTRACTED_FILE}" &
+          local TMP_PID="$!"
+          store_kill_pids "${TMP_PID}"
+          WAIT_PIDS_S02+=( "${TMP_PID}" )
+          max_pids_protection "${MAX_MOD_THREADS}" "${WAIT_PIDS_S02[@]}"
+        else
+          fwhunter "${EXTRACTED_FILE}"
+        fi
+      done
+    fi
   fi
 
   [[ ${THREADED} -eq 1 ]] && wait_for_pid "${WAIT_PIDS_S02[@]}"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fwhunt first is run on the unextracted firmware, if it does not find anything, it continues checking each file in a for loop


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
