### PR TITLE
new version strings and comment for fwhunt

### DIFF
--- a/config/bin_version_strings.cfg
+++ b/config/bin_version_strings.cfg
@@ -117,6 +117,7 @@ insmod;;unknown;"insmod\ [0-9](\.[0-9]+)+?\ --\ part\ of\ module-init-tools$";"s
 modinfo;;unknown;"modinfo\ [0-9](\.[0-9]+)+?\ --\ part\ of\ module-init-tools$";"sed -r 's/modinfo\ ([0-9](\.[0-9]+)+?)\ .*/modinfo:\1/'";
 modprobe;;unknown;"modprobe\ [0-9](\.[0-9]+)+?\ --\ part\ of\ module-init-tools$";"sed -r 's/modprobe\ ([0-9](\.[0-9]+)+?)\ .*/modprobe:\1/'";
 davfs2;;gplv3;"^davfs2\ [0-9](\.[0-9]+)+?$";"sed -r 's/davfs2\ ([0-9](\.[0-9]+)+?)$/davfs2:\1/'";
+delphi;;unknown;"^Embarcadero Delphi for Win32 compiler version [0-9]+\.[0-9]\ \([0-9]+\.[0-9]\.[0-9]+\.[0-9]+\)$";"sed -r 's/^Embarcadero Delphi for Win32 compiler version [0-9]+\.[0-9]\ \(([0-9]+\.[0-9]\.[0-9]+\.[0-9]+)\)$/embarcadero:embarcadero_delphi_xe6:\1/'";
 dhcpcd;;unknown;"DHCP\ Client\ Daemon\ v\.[0-9](\.[0-9]+)+?(-p[0-9]+)?";"sed -r 's/DHCP\ Client\ Daemon\ v\.([0-9](\.[0-9]+)+?(-p[0-9]+)?).*/dhcpcd:\1/'";
 dhcpfwd;;unknown;"dhcp-forwarder\ [0-9](\.[0-9])+?$";"sed -r 's/dhcp-forwarder\ ([0-9](\.[0-9]+)+?)$/dhcp-forwarder:\1/'";
 dhtest;;gplv2;"dhtest\ version\ [0-9](\.[0-9]+)+?$";"sed -r 's/dhtest\ version\ ([0-9](\.[0-9]+)+?)$/dhtest:\1/'";

--- a/config/bin_version_strings.cfg
+++ b/config/bin_version_strings.cfg
@@ -260,6 +260,7 @@ info-zip;;bsd-style;"Zip\ [0-9](\.[0-9]+)+?\ .*,\ by Info-ZIP";"sed -r 's/Zip\ (
 info-zip;;bsd-style;"ZipCloak\ [0-9](\.[0-9]+)+?\ .*,\ by Info-ZIP";"sed -r 's/ZipCloak\ ([0-9](\.[0-9]+)+?).*/info-zip:zipcloak:\1/'";
 info-zip;;bsd-style;"ZipInfo\ [0-9](\.[0-9]+)+?\ of\ .*\ by\ Greg\ Roelofs\ and\ the\ Info-ZIP\ group\.";"sed -r 's/ZipInfo\ ([0-9](\.[0-9]+)+?).*/info-zip:zip:\1/'";
 info-zip;;bsd-style;"ZipNote\ [0-9](\.[0-9]+)+?\ .*,\ by Info-ZIP";"sed -r 's/ZipNote\ ([0-9](\.[0-9]+)+?).*/info-zip:zipnote:\1/'";
+inno_setup;;unknown;"^Inno\ Setup\ Messages\ \([0-9]\.[0-9]\.[0-9]\)\ \(u\)";"sed -r 's/^Inno\ Setup\ Messages\ \([0-9]\.[0-9]\.[0-9]\)\ \(u\)/jrsoftware:inno_setup/'";
 inotifywatch;;unknown;"^inotifywatch\ [0-9](\.[0-9]+)+?$";"sed -r 's/inotifywatch\ ([0-9](\.[0-9]+)+?)$/inotify-tools:\1/'";
 inotifywait;;unknown;"^inotifywait\ [0-9](\.[0-9]+)+?$";"sed -r 's/inotifywait\ ([0-9](\.[0-9]+)+?)$/inotify-tools:\1/'";
 intel_trusted_device_setup;;unknown;"^Intel\(R\)\ Trusted\ Device\ Setup\ Extension\ Version\ [0-9]+(\.[0-9]+)+?$";"sed -r 's/Intel\(R\)\ Trusted\ Device\ Setup\ Extension\ Version\ ([0-9]+(\.[0-9]+)+?)/intel:trusted_device_setup:\1/'";

--- a/config/bin_version_strings.cfg
+++ b/config/bin_version_strings.cfg
@@ -260,7 +260,7 @@ info-zip;;bsd-style;"Zip\ [0-9](\.[0-9]+)+?\ .*,\ by Info-ZIP";"sed -r 's/Zip\ (
 info-zip;;bsd-style;"ZipCloak\ [0-9](\.[0-9]+)+?\ .*,\ by Info-ZIP";"sed -r 's/ZipCloak\ ([0-9](\.[0-9]+)+?).*/info-zip:zipcloak:\1/'";
 info-zip;;bsd-style;"ZipInfo\ [0-9](\.[0-9]+)+?\ of\ .*\ by\ Greg\ Roelofs\ and\ the\ Info-ZIP\ group\.";"sed -r 's/ZipInfo\ ([0-9](\.[0-9]+)+?).*/info-zip:zip:\1/'";
 info-zip;;bsd-style;"ZipNote\ [0-9](\.[0-9]+)+?\ .*,\ by Info-ZIP";"sed -r 's/ZipNote\ ([0-9](\.[0-9]+)+?).*/info-zip:zipnote:\1/'";
-inno_setup;;unknown;"^Inno\ Setup\ Messages\ \([0-9]\.[0-9]\.[0-9]\)\ \(u\)";"sed -r 's/^Inno\ Setup\ Messages\ \([0-9]\.[0-9]\.[0-9]\)\ \(u\)/jrsoftware:inno_setup/'";
+inno_setup;;unknown;"^Inno\ Setup\ Messages\ \([0-9]\.[0-9]\.[0-9]\)\ \(u\)";"sed -r 's/^Inno\ Setup\ Messages\ \(([0-9]\.[0-9]\.[0-9])\)\ \(u\)/jrsoftware:inno_setup:\1/'";
 inotifywatch;;unknown;"^inotifywatch\ [0-9](\.[0-9]+)+?$";"sed -r 's/inotifywatch\ ([0-9](\.[0-9]+)+?)$/inotify-tools:\1/'";
 inotifywait;;unknown;"^inotifywait\ [0-9](\.[0-9]+)+?$";"sed -r 's/inotifywait\ ([0-9](\.[0-9]+)+?)$/inotify-tools:\1/'";
 intel_trusted_device_setup;;unknown;"^Intel\(R\)\ Trusted\ Device\ Setup\ Extension\ Version\ [0-9]+(\.[0-9]+)+?$";"sed -r 's/Intel\(R\)\ Trusted\ Device\ Setup\ Extension\ Version\ ([0-9]+(\.[0-9]+)+?)/intel:trusted_device_setup:\1/'";

--- a/modules/S02_UEFI_FwHunt.sh
+++ b/modules/S02_UEFI_FwHunt.sh
@@ -31,6 +31,7 @@ S02_UEFI_FwHunt() {
 
   if [[ "${UEFI_VERIFIED}" -eq 1 ]] || { [[ "${RTOS}" -eq 1 ]] && [[ "${UEFI_DETECTED}" -eq 1 ]]; }; then
     print_output "[*] Starting FwHunter UEFI firmware vulnerability detection"
+    # we first analyze the entire firmware for performance reasons, if we do not find anything, we analyze each file
     fwhunter "${FIRMWARE_PATH_BAK}"
     if [[ $(grep -c "FwHunt rule" "${LOG_PATH_MODULE}""/fwhunt_scan_"* | cut -d: -f2 | awk '{ SUM += $1} END { print SUM }' || true) -eq 0 ]]; then
       for EXTRACTED_FILE in "${FILE_ARR_LIMITED[@]}"; do


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Strings found: 
1. "Embarcadero Delphi for Win32 compiler version 33.0 (26.0.33219.4899)" -> transformed into "embarcadero_delphi_xe6:26.0.33219.4899"
2. "Inno Setup Messages (5.5.3) (u)" -> transformed into "jrsoftware:inno_setup"

For inno_setup there is no version in the cve database, so I do not include it.

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
