### PR TITLE
Full system emulation dependency s24

### DIFF
--- a/emba
+++ b/emba
@@ -226,6 +226,12 @@ run_modules()
       fi
     done
   else
+    # in full emulation mode we need to ensure that module s24 is always running
+    if [[ "${MODULE_GROUP}" == "S" ]] && [[ "${FULL_EMULATION}" -eq 1 ]] && [[ ! "${SELECT_MODULES[@]}" =~ [sS]24 ]]; then
+      print_output "[*] Automatically enable module S24 for system emulation mode"
+      SELECT_MODULES+=("S24")
+    fi
+
     for SELECT_NUM in "${SELECT_MODULES[@]}" ; do
       local MOD_FIN=0
       if [[ "${SELECT_NUM}" =~ ^["${MODULE_GROUP,,}","${MODULE_GROUP^^}"]{1}[0-9]+ ]]; then

--- a/emba
+++ b/emba
@@ -227,7 +227,7 @@ run_modules()
     done
   else
     # in full emulation mode we need to ensure that module s24 is always running
-    if [[ "${MODULE_GROUP}" == "S" ]] && [[ "${FULL_EMULATION}" -eq 1 ]] && [[ ! "${SELECT_MODULES[@]}" =~ [sS]24 ]]; then
+    if [[ "${MODULE_GROUP}" == "S" ]] && [[ "${FULL_EMULATION}" -eq 1 ]] && [[ ! "${SELECT_MODULES[*]}" =~ [sS]24 ]]; then
       print_output "[*] Automatically enable module S24 for system emulation mode"
       SELECT_MODULES+=("S24")
     fi


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

s24 not automatically enabled in system emulation mode

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

automatically enable s24 when -Q parameter is used
