### PR TITLE
Fix parsing of version number from binary version string

### DIFF
--- a/modules/F20_vul_aggregator.sh
+++ b/modules/F20_vul_aggregator.sh
@@ -555,7 +555,7 @@ check_cve_sources() {
   local CVE_VER_SOURCES_FILE="${3:-}"
 
   local BIN_VERSION_ONLY=""
-  BIN_VERSION_ONLY=$(echo "${BIN_VERSION_}" | cut -d':' -f2)
+  BIN_VERSION_ONLY=$(echo "${BIN_VERSION_}" | rev | cut -d':' -f1 | rev)
   local BIN_NAME=""
   BIN_NAME=$(echo "${BIN_VERSION_}" | cut -d':' -f1)
   local CVE_VER_START_INCL=""


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
For a binary version string like "openssl:openssl:1.0.1j", current code returns "openssl" for the version instead of "1.0.1j", causing false positives to be returned.


* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**
Updated code returns the last field of the binary version string, which should be the correct version number.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
I don't believe so.


* **Other information**:
I did a quick test to verify this works for the openssl example mentioned above, but did not perform any further testing. Also not sure if a similar change might be necessary for BIN_NAME (should it always be the first field? or should it be the second to last field in the case where there are 3+ fields?).