### PR TITLE
remove disable shellcheck from installer folder scripts

### DIFF
--- a/installer/IL15_emulated_checks_init.sh
+++ b/installer/IL15_emulated_checks_init.sh
@@ -111,10 +111,12 @@ IL15_emulated_checks_init() {
         sed -i 's/routersploit\.log/\/tmp\/routersploit\.log/' ./rsf.py
       fi
       # patch some code to write the history files to a subdirectory in /root
-      if grep -q  '\~/.history' ./routersploit/interpreter.py; then
+      # shellcheck disable=SC2088 (needed because we do not want to expand the tilde)
+      if grep -q  '~/.history' ./routersploit/interpreter.py; then
         sed -i 's/~\/\.history/~\/\.routersploit\/\.history/' ./routersploit/interpreter.py
       fi
-      if grep -q  '\~/.rsf_history' ./routersploit/interpreter.py; then
+      # shellcheck disable=SC2088 (needed because we do not want to expand the tilde)
+      if grep -q  '~/.rsf_history' ./routersploit/interpreter.py; then
         sed -i 's/~\/\.rsf_history/~\/\.routersploit\/\.rsf_history/' ./routersploit/interpreter.py
       fi
 

--- a/installer/IL15_emulated_checks_init.sh
+++ b/installer/IL15_emulated_checks_init.sh
@@ -111,10 +111,10 @@ IL15_emulated_checks_init() {
         sed -i 's/routersploit\.log/\/tmp\/routersploit\.log/' ./rsf.py
       fi
       # patch some code to write the history files to a subdirectory in /root
-      if grep -q  ~/'.history' ./routersploit/interpreter.py; then
+      if grep -q  '\~/.history' ./routersploit/interpreter.py; then
         sed -i 's/~\/\.history/~\/\.routersploit\/\.history/' ./routersploit/interpreter.py
       fi
-      if grep -q  ~/'.rsf_history' ./routersploit/interpreter.py; then
+      if grep -q  '\~/.rsf_history' ./routersploit/interpreter.py; then
         sed -i 's/~\/\.rsf_history/~\/\.routersploit\/\.rsf_history/' ./routersploit/interpreter.py
       fi
 

--- a/installer/IL15_emulated_checks_init.sh
+++ b/installer/IL15_emulated_checks_init.sh
@@ -111,11 +111,13 @@ IL15_emulated_checks_init() {
         sed -i 's/routersploit\.log/\/tmp\/routersploit\.log/' ./rsf.py
       fi
       # patch some code to write the history files to a subdirectory in /root
-      # shellcheck disable=SC2088 (needed because we do not want to expand the tilde)
+      # shellcheck disable=SC2088
+      # we do not want to expand the tilde
       if grep -q  '~/.history' ./routersploit/interpreter.py; then
         sed -i 's/~\/\.history/~\/\.routersploit\/\.history/' ./routersploit/interpreter.py
       fi
-      # shellcheck disable=SC2088 (needed because we do not want to expand the tilde)
+      # shellcheck disable=SC2088
+      # we do not want to expand the tilde
       if grep -q  '~/.rsf_history' ./routersploit/interpreter.py; then
         sed -i 's/~\/\.rsf_history/~\/\.routersploit\/\.rsf_history/' ./routersploit/interpreter.py
       fi

--- a/installer/IL15_emulated_checks_init.sh
+++ b/installer/IL15_emulated_checks_init.sh
@@ -111,12 +111,10 @@ IL15_emulated_checks_init() {
         sed -i 's/routersploit\.log/\/tmp\/routersploit\.log/' ./rsf.py
       fi
       # patch some code to write the history files to a subdirectory in /root
-      # shellcheck disable=SC2088
-      if grep -q  '~/.history' ./routersploit/interpreter.py; then
+      if grep -q  ~/'.history' ./routersploit/interpreter.py; then
         sed -i 's/~\/\.history/~\/\.routersploit\/\.history/' ./routersploit/interpreter.py
       fi
-      # shellcheck disable=SC2088
-      if grep -q  '~/.rsf_history' ./routersploit/interpreter.py; then
+      if grep -q  ~/'.rsf_history' ./routersploit/interpreter.py; then
         sed -i 's/~\/\.rsf_history/~\/\.routersploit\/\.rsf_history/' ./routersploit/interpreter.py
       fi
 

--- a/installer/wickStrictModeFail.sh
+++ b/installer/wickStrictModeFail.sh
@@ -37,8 +37,7 @@ wickStrictModeFail() (
     if [[ ${#BASH_ARGC[@]} -gt ${i} ]] && [[ ${#BASH_ARGV[@]} -ge $(( nextArg + BASH_ARGC[i] )) ]]; then
       for (( argsLeft = BASH_ARGC[i]; argsLeft; --argsLeft )); do
         # Note: this reverses the order on purpose
-        # shellcheck disable=SC2004
-        argsList[${argsLeft}]=${BASH_ARGV[nextArg]}
+        argsList[argsLeft]=${BASH_ARGV[nextArg]}
         (( nextArg ++ ))
       done
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
no need for "disable shellcheck" in the installer scripts


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
