### PR TITLE
Fix parsing of binary name from binary version string

### DIFF
--- a/modules/F20_vul_aggregator.sh
+++ b/modules/F20_vul_aggregator.sh
@@ -557,7 +557,7 @@ check_cve_sources() {
   local BIN_VERSION_ONLY=""
   BIN_VERSION_ONLY=$(echo "${BIN_VERSION_}" | rev | cut -d':' -f1 | rev)
   local BIN_NAME=""
-  BIN_NAME=$(echo "${BIN_VERSION_}" | cut -d':' -f1)
+  BIN_NAME=$(echo "${BIN_VERSION_}" | rev | cut -d':' -f2 | rev)
   local CVE_VER_START_INCL=""
   local CVE_VER_START_EXCL=""
   local CVE_VER_END_INCL=""


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Code currently pulls binary name from the first field of the binary version string, like so:

bin_name:version

But in some cases we have an identifier like the following:

vendor:bin_name:version


* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**
Updated code pulls binary name from second to last field of the binary version string, which should better handle cases in which there are 3+ fields, as described above.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Hopefully not!


* **Other information**:
