### PR TITLE
Multi grep in version detection

### DIFF
--- a/config/bin_version_strings.cfg
+++ b/config/bin_version_strings.cfg
@@ -18,7 +18,8 @@
 # strict -> only use this regex on files with the name of the identifier
 # no_static -> typically this rule produces false positives in static analysis -> only use this rule in emulation mode
 # zgrep -> find file named in the identifier field, executes zgrep on the file(s) with the "version identifier" field as search string -> early alpha state!
-# multi_grep -> multiple identifiers are checked
+# multi_grep -> multiple identifiers are checked. These identifiers need to be in the format '"IDENTIFIER1"&&"IDENTIFIER2"&&"IDENTIFIER3"'. The last identifier needs to be the
+#               version identifier that is used for the cve query
 # live -> version identifier found via live tester modules
 # license -> unknown/gpl/gplv2/gplv3/mit/proprietary
 # version transformation regex -> the regex needed to transform the version for the cve-database request / NA if not available

--- a/config/bin_version_strings.cfg
+++ b/config/bin_version_strings.cfg
@@ -658,6 +658,7 @@ sysvinit;;unknown;"^INIT_VERSION\=sysvinit-[0-9]\.(\.[0-9]+)+?$";"sed -r 's/INIT
 tar;;unknown;"\(GNU\ tar\)\ [0-9](\.[0-9]+)+?$";"sed -r 's/\(GNU\ tar\)\ ([0-9](\.[0-9]+)+?)$/gnu:tar:\1/'";
 tcci;;unknown;"^\ tcci\ version:\ tcci\ V[0-9](\.[0-9]+)+?\ ";"sed -r 's/\ tcci\ version:\ tcci\ V([0-9](\.[0-9]+)+?)\ .*/tcci:\1/'";
 tcpdump;strict;bsd;"^[0-9]\.[0-9]+\.[0-9]+$";"sed -r 's/([0-9](\.[0-9]+)+?)$/tcpdump:\1/'";
+tcpdump;multi_grep;bsd;'"^dump$"&&"^\[\ -T\ type\ \]\ \[\ --version\ \]\ \[\ -V\ file\ \]$"&&"^[0-9](\.[0-9]+)+?$"';"sed -r 's/([0-9](\.[0-9]+)+?)/tcpdump:\1/'";
 tcpdump;;bsd;"tcpdump\.[0-9](\.[0-9]+)+?\ version";"sed -r 's/tcpdump\.([0-9](\.[0-9]+)+?)\ version/tcpdump:\1/'";
 tcpdump;;bsd;"^tcpdump\ version\ [0-9](\.[0-9]+)+?$";"sed -r 's/tcpdump\ version\ ([0-9](\.[0-9]+)+?)$/tcpdump:\1/'";
 tempfile;;unknown;"^tempfile\ [0-9][\.0-9]+$";"sed -r 's/tempfile\ ([0-9](\.[0-9]+)+?(p[0-9]+)?)$/tempfile:\1/'";
@@ -667,8 +668,8 @@ sthttpd;;bsd;"^sthttpd\/[0-9](\.[0-9]+)+?([a-z])?.*";"sed -r 's/sthttpd\/([0-9]+
 tinylogin;;gplv2;"Tinylogin v[0-9](\.[0-9]+)+?\ \(.*\)\ multi-call\ binary$";"sed -r 's/Tinylogin\ v([0-9](\.[0-9]+)+?)\ .*/busybox:\1/'";
 tor;;unknown;"Tor\ v[0-9](\.[0-9]+)+?\ .git";"sed -r 's/Tor\ v([0-9](\.[0-9]+)+?)\ .*/tor:\1/'";
 traceroute;;gplv2;"traceroute\.db\:\ Modern\ traceroute\ for\ Linux,\ version\ [0-9](\.[0-9]+)+?,\ [[:alpha:]]{3}\ [0-9]+\ [0-9]+";"sed -r 's/traceroute\.db\:\ Modern\ traceroute\ for\ Linux,\ version\ ([0-9](\.[0-9]+)+?)\ .*/traceroute:\1/'";
-traceroute;;unknown;"^Modern\ traceroute\ for\ Linux,\ [Vv]ersion\ [0-9]+(\.[0-9]+)+?";"sed -r 's/Modern\ traceroute\ for\ Linux,\ [Vv]ersion\ ([0-9]+(\.[0-9]+)+?)$/traceroute:\1/'";
-traceroute;strict;unknown;"^Version\ [0-9]\.[0-9]+a[0-9]+";"sed -r 's/Version\ ([0-9](\.[0-9]+)+?).*/traceroute:\1/'";
+traceroute;;gplv2;"^Modern\ traceroute\ for\ Linux,\ [Vv]ersion\ [0-9]+(\.[0-9]+)+?";"sed -r 's/Modern\ traceroute\ for\ Linux,\ [Vv]ersion\ ([0-9]+(\.[0-9]+)+?)$/traceroute:\1/'";
+traceroute;strict;gplv2;"^Version\ [0-9]\.[0-9]+a[0-9]+";"sed -r 's/Version\ ([0-9](\.[0-9]+)+?).*/traceroute:\1/'";
 transmissionbt;;mit,gpl;"^Transmission\ [0-9]+(\.[0-9]+)+?\ \(\)\ \ http\:\/\/www\.transmissionbt\.com\/$";"sed -r 's/Transmission\ ([0-9]+(\.[0-9]+)+?)\ .*/transmission:transmissionbt:\1/'";
 transmissionbt;;mit,gpl;"^transmission-cli\ [0-9]\.[0-9]+\ \([0-9]+\)$";"sed -r 's/transmission-cli\ ([0-9](\.[0-9]+)+?)\ .*/transmission:transmissionbt:\1/'";
 trigger;;unknown;"trigger\ version\ [0-9]+$";"sed -r 's/trigger\ version\ ([0-9]+)$/trigger:\1/'";

--- a/config/bin_version_strings.cfg
+++ b/config/bin_version_strings.cfg
@@ -89,6 +89,7 @@ cape;;unknown;"^cape\ [0-9](\.[0-9])+?$";"sed -r 's/cape\ ([0-9](\.[0-9]+)+?)$/c
 candump;;gplv2;"^candump\ [0-9]+(\.[0-9]+)+?$";"sed -r 's/candump\ ([0-9]+(\.[0-9]+)+?)$/can-utils:\1/'";
 cansequence;;gplv2;"^cansequence\ [0-9](\.[0-9]+)+?$";"sed -r 's/cansequence\ ([0-9]+(\.[0-9]+)+?)$/can-utils:\1/'";
 ccrypt;;gplv2+;"ccrypt\ [0-9](\.[0-9]+)+?\.\ Secure\ encryption\ and\ decryption\ of\ files\ and\ streams\.";"sed -r 's/ccrypt\ ([0-9]+(\.[0-9]+)+?).*/ccrypt:\1/'";
+ccrypt;multi_grep;gplv2+;'"^ccrypt$"&&"^\%s\ \%s\.\ Secure\ encryption\ and\ decryption\ of\ files\ and\ streams\.$"&&"[0-9](\.[0-9]+)+?";"sed -r 's/([0-9]+(\.[0-9]+)+?)/ccrypt:\1/'";
 cdialog;;unknown;"^cdialog\ .+\ version\ [0-9]\.[0-9]-[0-9]+";"sed -r 's/cdialog\ .*\ version\ ([0-9]+(\.[0-9]+)+?).*/cdialog:\1/'";
 chillispot;;unknown;"^chillispot\ [0-9](\.[0-9]+)+?$";"sed -r 's/chillispot\ ([0-9]+(\.[0-9]+)+?).*/chillispot:\1/'";
 chrony;;unknown;"^chrony[cd]\ \(chrony\)\ version\ [0-9]\.[0-9]+";"sed -r 's/chrony[cd]\ \(chrony\)\ version\ ([0-9]+(\.[0-9]+)+?)/chrony:\1/'";
@@ -329,6 +330,7 @@ glibc;;lgpl;"GNU\ C\ Library\ development\ release\ version\ [0-9](\.[0-9]+)+?$"
 glibc;;lgpl;"GNU\ C\ Library\ \(.*\)\ stable\ release\ version\ [0-9](\.[0-9]+)+?(\.)?$";"sed -r 's/GNU\ C\ Library\ \(.*\)\ stable\ release\ version\ ([0-9](\.[0-9]+)+?)$/gnu:glibc:\1/'";
 libcurl;;mit-style;"CLIENT\ libcurl\ [0-9](\.[0-9]+)+?";"sed -r 's/CLIENT\ libcurl\ ([0-9](\.[0-9]+)+?).*/libcurl:\1/'";
 libcurl;;mit-style;"^libcurl\/[0-9](\.[0-9]+)+?$";"sed -r 's/libcurl\/([0-9](\.[0-9]+)+?)$/libcurl:\1/'";
+libdev;multi_grep;unknown;'"^libdev$"&&"libev:\ loop\ to\ be\ embedded\ is\ not\ embeddable"&&"^[0-9](\.[0-9]+)?+$"';"sed -r 's/([0-9](\.[0-9]+)+?)$/libdev:\1/'";
 libexpat;;unknown;"expat_[0-9]\.[0-9]+\.[0-9]+$";"sed -r 's/expat_([0-9](\.[0-9]+)+?)$/expat:\1/'";
 libgcrypt;;lgplv2.1;"[Ll]ibgcrypt\ [0-9](\.[0-9]+)+?\ ";"sed -r 's/[Ll]ibgcrypt\ ([0-9](\.[0-9]+)+?)\ .*/libgcrypt:\1/'";
 libgcrypt;;lgplv2.1;"[Ll]ibgcrypt\ [0-9](\.[0-9]+)+?$";"sed -r 's/[Ll]ibgcrypt\ ([0-9](\.[0-9]+)+?)$/libgcrypt:\1/'";
@@ -343,7 +345,6 @@ libgpiod;;lgpl;"^gpiomon\ \(libgpiod\)\ [0-9](\.[0-9]+)+?$";"sed -r 's/gpiomon\ 
 libsoup;;lgpl;"^libsoup\/[0-9](\.[0-9]+)+?$";"sed -r 's/^libsoup\/([0-9](\.[0-9]+)+?)$/libsoup:\1/'";
 libmicrohttpd.so.12;strict;lgplv2.1;"^[0-9]\.[0-9](\.[0-9]+)+?$";"sed -r 's/^([0-9]\.[0-9](\.[0-9]+)+?)/gnu:libmicrohttpd:\1/'";
 libharfbuzz.so.0;strict;mit;"^[0-9]\.[0-9](\.[0-9]+)+?$";"sed -r 's/^([0-9]\.[0-9](\.[0-9]+)+?)/harfbuzz_project:harfbuzz:\1/'";
-libnss3.so;strict;unknown;"^[0-9](\.[0-9]+)+?$";"sed -r 's/([0-9](\.[0-9]+)+?)$/libnss3:\1/'";
 libnss3;multi_grep;unknown;'"nss_DumpCertificateCacheInfo"&&"^[0-9](\.[0-9]+)?+$"';"sed -r 's/([0-9](\.[0-9]+)+?)$/libnss3:\1/'";
 libpcap;;bsd;"^libpcap\ version\ [0-9](\.[0-9]+)+?$";"sed -r 's/libpcap\ version\ ([0-9](\.[0-9]+)+?)$/libpcap:\1/'";
 libpcre;;bsd;"libpcre\.so\.[0-9]\.[0-9](\.[0-9]+)+?$";"sed -r 's/libpcre\.so\.([0-9](\.[0-9]+)+?)$/pcre:\1/'";
@@ -365,6 +366,7 @@ linux_kernel;;gplv2;"Linux\ kernel\ version\ [1-6]\.[0-9]+\.[0-9]+\ ";"sed -r 's
 linux_kernel;;gplv2;"Linux\ kernel\ version\ [1-6]\.[0-9]+\.[0-9]+$";"sed -r 's/Linux\ kernel\ version\ ([1-6](\.[0-9]+)+?)$/linux_kernel:\1/'";
 linux_kernel;;gplv2;"Linux\ version\ [1-6]\.[0-9]+\.[0-9]+\ ";"sed -r 's/Linux\ version\ ([1-6](\.[0-9]+)+?)\ .*/linux_kernel:\1/'";
 linux_kernel;;gplv2;"Linux\ version\ [1-6]\.[0-9]+\.[0-9]+$";"sed -r 's/Linux\ version\ ([1-6](\.[0-9]+)+?)$/linux_kernel:\1/'";
+linuxptp;multi_grep;gplv2;'"^PTP_CLOCK_GETCAPS$"&&"^PTP_PIN_SETFUNC2\ failed:\ \%m$"&&"^[0-9](\.[0-9]+)+?$"';"sed -r 's/([0-9](\.[0-9]+)+?)/linuxptp_project:linuxptp:\1/'";
 lldpd;;unknown;"^Version:\ lldpd\ [0-9](\.[0-9]+)+$";"sed -r 's/Version:\ lldpd\ ([0-9](\.[0-9]+)+?)$/lldpd:\1/'";
 llmnresp;;unknown;"^llmnresp\ versoin\ [0-9](\.[0-9]+)+?$";"sed -r 's/llmnresp\ versoin\ ([0-9](\.[0-9]+)+?)$/llmnresp:\1/'";
 lnstat;;unknown;"lnstat\ Version\ [0-9]\.[0-9]+(\ [0-9]+)?$";"sed -r 's/lnstat\ Version\ ([0-9](\.[0-9]+)+?).*/lnstat:\1/'";
@@ -558,6 +560,7 @@ ptpd2;;unknown;"ptpd2\ version\ [0-9]\.[0-9]+\.[0-9]+";"sed -r 's/ptpd2\ version
 pure-ftpd;;bsd;"pure-ftpd\ v[0-9](\.[0-9]+)+?\ \[privsep\]$";"sed -r 's/pure-ftpd\ v([0-9](\.[0-9]+)+?).*/pure-ftpd:\1/'";
 python;;psf-license;"^Python\ [0-9]\.[0-9]+\.[0-9]+\ ";"sed -r 's/Python\ ([0-9](\.[0-9]+)+?)\ .*/python:\1/'";
 python;;psf-license;"^Python\ [0-9](\.[0-9]+)+?$";"sed -r 's/Python\ ([0-9](\.[0-9]+)+?)$/python:\1/'";
+pyexpat;multi_grep;unknown;'"^pyexpat$"&&"^Python\ wrapper\ for\ Expat\ parser\.$"&&"^sqlite3_bind_parameter_index$"&&"^[0-9](\.[0-9]+)?+$"';"sed -r 's/([0-9](\.[0-9]+)+?)$/pyexpat:\1/'";
 #qmi;;unknown;"^qmi[-a-z]+\ [.\0-9]+$";"NA";
 qnx;;unknown;"Welcome\ to\ QNX\ Neutrino\ [0-9](\.[0-9]+)+?$";"sed -r 's/Welcome\ to\ QNX\ Neutrino\ ([0-9](\.[0-9]+)+?)$/qnx_neutrino_rtos:\1/'";
 qrencode;;unknown;"^qrencode\ version\ [0-9](\.[0-9]+)+?$";"sed -r 's/qrencode\ version\ ([0-9](\.[0-9]+)+?)$/qrencode:\1/'";
@@ -594,6 +597,7 @@ rsync;;unknown;"^rsync\ \ version\ [0-9](\.[0-9]+)+?\ \ protocol\ version\ [0-9]
 rsyslogd;;unknown;"rsyslogd\ [0-9](\.[0-9]+)+?,\ compiled\ with:$";"sed -r 's/rsyslogd\ ([0-9](\.[0-9]+)+?),\ .*/rsyslogd:\1/'";
 rsyslogd;;unknown;"^rsyslogd\ [0-9](\.[0-9]+)+?\ runtime\ debug\ support\ -\ help\ requested,\ rsyslog\ terminates$";"sed -r 's/rsyslogd\ ([0-9](\.[0-9]+)+?)\ .*/rsyslogd:\1/'";
 rsyslogd;;unknown;"^liblogging-stdlog\ version\ [0-9](\.[0-9]+)+?$";"sed -r 's/liblogging-stdlog\ version\ ([0-9](\.[0-9]+)+?).*/rsyslog:\1/'";
+rsyslogd;multi_grep;unknown;'":\ module\ compiled\ with\ rsyslog\ version\ \%s.$"&&"[0-9](\.[0-9]+)+?$"';"sed -r 's/([0-9](\.[0-9]+)+?)/rsyslogd:\1/'";
 rt2860apd;;unknown;"Ralink\ DOT1X\ daemon,\ version\ =\ .[0-9](\.[0-9])+?\'\ ";"sed -r 's/Ralink\ DOT1X\ daemon,\ version\ =\ .([0-9](\.[0-9]+)+?)\ .*/ralink-dot1x:\1/'";
 rtpproxy;strict;unknown;"^Basic\ version:\ [0-9]+$";"sed -r 's/Basic\ version:\ ([0-9]+)$/rtpproxy:\1/'";
 run-parts;;unknown;"run-parts\ program,\ version\ [\.0-9]+$";"sed -r 's/run-parts\ program,\ version\ ([0-9](\.[0-9]+)+?)$/run-parts:\1/'";
@@ -629,10 +633,7 @@ snort;strict;gplv2;"^Version\ [0-9](\.[0-9])+?";"sed -r 's/Version:\ ([0-9](\.[0
 socat;;gplv2;"socat\ version\ [0-9](\.[0-9]+)+?-[a-z][0-9]+\ ";"sed -r 's/socat\ version\ ([0-9](\.[0-9]+)+?)((-[a-z][0-9]+)?)\ .*/socat:\1:\2/'";
 socat;;gplv2;"socat\ version\ [0-9](\.[0-9]+)+?\ ";"sed -r 's/socat\ version\ ([0-9](\.[0-9]+)+?)\ .*/socat:\1/'";
 sqlite3;;public-domain;"SQLite\ version\ 3(\.[0-9]+)+?";"sed -r 's/SQLite\ version\ (3(\.[0-9]+)+?).*/sqlite:\1/'";
-sqlite3;strict;public-domain;"^3\.[0-9]+\.[0-9]+\ ";"sed -r 's/(3(\.[0-9]+)+?)\ /sqlite:\1/'";
-sqlite3;strict;public-domain;"^3\.[0-9]+\.[0-9]+$";"sed -r 's/(3(\.[0-9]+)+?)$/sqlite:\1/'";
-sqlite3;strict;public-domain;"^3\.[0-9]+\.[0-9]+\ ";"sed -r 's/(3(\.[0-9]+)+?)\ /sqlite:\1/'";
-sqlite3;;public-domain;"SQLite\ version\ 3(\.[0-9]+)+?";"sed -r 's/SQLite\ version\ (3(\.[0-9]+)+?).*/sqlite:\1/'";
+sqlite3;multi_grep;unknown;'"^sqlite3_version$"&&"^sqlite3_bind_parameter_index$"&&"^[0-9](\.[0-9]+)?+$"';"sed -r 's/([0-9](\.[0-9]+)+?)$/sqlite3:\1/'";
 libsqlite3.so.0;strict;public-domain;"^3\.[0-9]+\.[0-9]+$";"sed -r 's/(3(\.[0-9]+)+?)$/sqlite:\1/'";
 squidclient;strict;unknown;"Version:\ [0-9]\.[0-9]\.[0-9]";"sed -r 's/Version:\ ([0-9](\.[0-9]+)+?)/squidclient:\1/'";
 squidguard;;unknown;"SquidGuard:\ [0-9]\.[0-9]\ Berkeley\ DB\ [0-9]\.[0-9]\.[0-9]+";"sed -r 's/SquidGuard:\ ([0-9](\.[0-9]+)+?)\ .*/squidguard:\1/'";
@@ -723,6 +724,7 @@ watchdog;;unknown;"watchdog\ version\ [0-9](\.[0-9]+)+?,\ usage\:";"sed -r 's/wa
 watchquagga;;gpl;"watchquagga\ version\ [0-9](\.[0-9]+)+?";"sed -r 's/watchquagga\ version\ ([0-9](\.[0-9]+)+?).*$/quagga:\1/'";
 wget;;gplv3;"Wget\ [0-9](\.[0-9]+)+?,\ a\ non-interactive\ network\ retriever";"sed -r 's/Wget\ ([0-9](\.[0-9]+)+?),\ a\ .*/wget:\1/'";
 wget;;gplv3;"Wget\ [0-9](\.[0-9]+)+?\ built\ on\ ";"sed -r 's/Wget\ ([0-9](\.[0-9]+)+?)\ built\ on.*/wget:\1/'";
+wget;multi_grep;gplv3;'"^GNU Wget %s, a non-interactive network retriever.$"&&"[0-9](\.[0-9]+)+?"';"sed -r 's/([0-9](\.[0-9]+)+?)/wget:\1/'";
 whatis;;unknown;"whatis\ [0-9](\.[0-9]+)+?$";"sed -r 's/whatis\ ([0-9](\.[0-9]+)+?)$/whatis:\1/'";
 which;;gplv2+;"^GNU\ which\ v[0-9]\.[0-9]+.*";"sed -r 's/GNU\ which\ v([0-9](\.[0-9]+)+?).*/gnu:which:\1/'";
 whiptail;;unknown;"whiptail\ \(newt\):\ [0-9](\.[0-9]+)+?";"sed -r 's/whiptail\ \(newt\):\ ([0-9](\.[0-9]+)+?)/whiptail:\1/'";

--- a/config/bin_version_strings.cfg
+++ b/config/bin_version_strings.cfg
@@ -228,6 +228,7 @@ grub;;gplv3;"\ \(GRUB\)\ [0-9](\.[0-9]+)+?";"sed -r 's/\ \(GRUB\)\ ([0-9](\.[0-9
 grubinst;;unknown;"grubinst\ version\ :\ [0-9](\.[0-9]+)+?$";"sed -r 's/grubinst\ version\ :\ ([0-9](\.[0-9]+)+?)$/grubinst:\1/'";
 gsoap;;gplv2;"gSOAP\/[0-9](.[0-9]+)+?";"sed -r 's/gSOAP\/([0-9](\.[0-9]+)+?).*/gsoap:\1/'";
 gzip;;unknown;"gzip\ [0-9](\.[0-9]+)+?$";"sed -r 's/gzip\ ([0-9](\.[0-9]+)+?)$/gzip:\1/'";
+gzip;multi_grep;unknown;'"^GZIP$"&&"^Written\ by\ Jean-loup\ Gailly\.$"&&"^Report\ bugs\ to\ <bug-gzip@gnu\.org>\.$"&&"^[0-9](\.[0-9]+)+?$"';"sed -r 's/([0-9](\.[0-9]+)+?)$/gzip:\1/'";
 gzip;strict;unknown;"Version:\ [0-9](\.[0-9]+)+?$";"sed -r 's/Version:\ ([0-9](\.[0-9]+)+?)$/gzip:\1/'";
 haserl;;unknown;"^This\ is\ haserl\ version\ [0-9](\.[0-9]+)+?\ \(http\:\/\/haserl\.sourceforge\.net\)$";"sed -r 's/This\ is\ haserl\ version\ ([0-9](\.[0-9]+)+?)\ .*/haserl:\1/'";
 hciemu;;gplv2;"hciemu\ -\ HCI\ emulator\ ver\ [0-9]+(\.[0-9]+)+?$";"sed -r 's/hciemu\ -\ HCI\ emulator\ ver\ ([0-9]+(\.[0-9]+)+?)$/bluez_project:hciemu:\1/'";
@@ -342,6 +343,7 @@ libsoup;;lgpl;"^libsoup\/[0-9](\.[0-9]+)+?$";"sed -r 's/^libsoup\/([0-9](\.[0-9]
 libmicrohttpd.so.12;strict;lgplv2.1;"^[0-9]\.[0-9](\.[0-9]+)+?$";"sed -r 's/^([0-9]\.[0-9](\.[0-9]+)+?)/gnu:libmicrohttpd:\1/'";
 libharfbuzz.so.0;strict;mit;"^[0-9]\.[0-9](\.[0-9]+)+?$";"sed -r 's/^([0-9]\.[0-9](\.[0-9]+)+?)/harfbuzz_project:harfbuzz:\1/'";
 libnss3.so;strict;unknown;"^[0-9](\.[0-9]+)+?$";"sed -r 's/([0-9](\.[0-9]+)+?)$/libnss3:\1/'";
+libnss3;multi_grep;unknown;'"nss_DumpCertificateCacheInfo"&&"^[0-9](\.[0-9]+)?+$"';"sed -r 's/([0-9](\.[0-9]+)+?)$/libnss3:\1/'";
 libpcap;;bsd;"^libpcap\ version\ [0-9](\.[0-9]+)+?$";"sed -r 's/libpcap\ version\ ([0-9](\.[0-9]+)+?)$/libpcap:\1/'";
 libpcre;;bsd;"libpcre\.so\.[0-9]\.[0-9](\.[0-9]+)+?$";"sed -r 's/libpcre\.so\.([0-9](\.[0-9]+)+?)$/pcre:\1/'";
 libpng;;libpng;"libpng\ version\ [0-9](\.[0-9]+)+?\ ";"sed -r 's/libpng\ version\ ([0-9](\.[0-9]+)+?)\ .*/libpng:\1/'";
@@ -405,10 +407,9 @@ midnight_commander;;gplv3;"GNU\ Midnight\ Commander\ [0-9](\.[0-9]+)+?";"sed -r 
 mii-tool;;gplv2;"mii-tool\.c\ [0-9]\.[0-9]+\ .*\ \(David\ Hinds\)";"sed -r 's/mii-tool\.c\ ([0-9](\.[0-9]+)+?)\ .*/net-tools:mii-tool:\1/'";
 mikrotik-routeros;;;"MikroTik\ routerOS\ V[0-9]\.[0-9]+\ \(c\) [0-9]+-[0-9].*";"sed -r 's/.*MikroTik\ routerOS\ V([0-9]\.[0-9]+)\ .*/mikrotik:routeros:\1/'";
 minicom;;gplv2;"minicom\ version\ [0-9](\.[0-9]+)+?";"sed -r 's/minicom\ version\ ([0-9](\.[0-9]+)+?)$/minicom:\1/'";
-minidlna;strict;gplv2;"^Version\ [0-9](\.[0-9]+)+?$";"sed -r 's/Version\ ([0-9](\.[0-9]+)+?)$/minidlna:\1/'";
-minidlna;strict;gplv2;"Version\ [0-9]\.[0-9]+\.[0-9]+";"sed -r 's/Version\ ([0-9](\.[0-9]+)+?).*/minidlna:\1/'";
 minidlna;;gplv2;"^Starting\ MiniDLNA\ version\ [0-9](\.[0-9]+)+?";"sed -r 's/Starting\ MiniDLNA\ version\ ([0-9](\.[0-9]+)+?)/minidlna:\1/'";
 minidlna;live;gplv2;"^MiniDLNA\ [0-9](\.[0-9]+)+?\ ";"sed -r 's/MiniDLNA\ ([0-9](\.[0-9]+)+?)\ .*/minidlna:\1/'";
+minidlna;multi_grep;unknown;'"MiniDLNA is already running. EXITING."&&"^[0-9](\.[0-9]+)?+$"';"sed -r 's/([0-9](\.[0-9]+)+?)$/minidlna:\1/'";
 mini_httpd;;unknown;"mini_httpd\/[0-9](\.[0-9]+)+?(\ [0-9]+)?";"sed -r 's/mini_httpd\/([0-9](\.[0-9]+)+?).*/acme:mini_httpd:\1/'";
 mini_httpd;live;unknown;"mini_httpd\ [0-9](\.[0-9]+)+?(\ [0-9]+)?";"sed -r 's/mini_httpd\ ([0-9](\.[0-9]+)+?).*/acme:mini_httpd:\1/'";
 miniupnpd;;unknown;"SERVER:.*UPnP\/[0-9](\.[0-9]+)+?\ MiniUPnPd\/[0-9](\.[0-9]+)+?$";"sed -r 's/SERVER:.*UPnP\/[0-9](\.[0-9]+)+?\ MiniUPnPd\/([0-9](\.[0-9]+)+?)$/miniupnpd:\2/'";
@@ -535,6 +536,7 @@ pppd;;unknown;"pppd\ version\ [0-9](\.[0-9]+)+?$";"sed -r 's/pppd\ version\ ([0-
 pppd;;unknown;"pppd\ version\ [0-9](\.[0-9]+)+?([a-z][0-9]+)?$";"sed -r 's/pppd\ version\ ([0-9](\.[0-9]+)+?)(([a-z][0-9]+)?)$/point-to-point_protocol:\1/'";
 pppoe-discovery;strict;unknown;"Version\ [0-9]\.[0-9]+([a-z])?$";"sed -r 's/Version\ ([0-9](\.[0-9]+)+?([a-z])?)$/pppoe-discovery:\1/'";
 pppoe;;unknown;"pppoe\ version\ [0-9](\.[0-9]+)+?";"sed -r 's/pppoe\ version\ ([0-9](\.[0-9]+)+?)$/pppoe:\1/'";
+rox2;;unknown;"User-Agent: Siemens Canada Limited - ROX2 - [0-9](\.[0-9]+)?+$";"sed -r 's/User-Agent: Siemens Canada Limited - ROX2 - ([0-9](\.[0-9]+)+?)$/siemens:ruggedcom_rox:\1/'";
 rp-pppoe;;gplv2;"^PPPoE\ Version\ [0-9](\.[0-9]+)+?,\ Copyright\ \(C\)\ [0-9]+\ Roaring\ Penguin\ Software\ Inc\.$";"sed -r 's/PPPoE\ Version ([0-9](\.[0-9]+)+?),\ Copyright\ \(C\)\ [0-9]+\ Roaring\ Penguin\ Software\ Inc\.$/roaring_penguin:pppoe:\1/'";
 rp-pppoe;;gplv2;"^PPPoE\ Version\ [0-9](\.[0-9]+)+?,\ Copyright\ \(C\)\ [0-9]+-[0-9]+\ Roaring\ Penguin\ Software\ Inc\.$";"sed -r 's/PPPoE\ Version ([0-9](\.[0-9]+)+?).*/roaring_penguin:pppoe:\1/'";
 rp-pppoe;;gplv2;"^PPPoE\ Version\ [0-9](\.[0-9]+)+?,\ Copyright\ .*\ Roaring\ Penguin\ Software\ Inc\.$";"sed -r 's/PPPoE\ Version ([0-9](\.[0-9]+)+?),\ Copyright\ .*\ Roaring\ Penguin\ Software\ Inc\.$/roaring_penguin:pppoe:\1/'";
@@ -610,7 +612,7 @@ signtools;;unknown;"^signver[-\ a-zA-Z7]+Version\ [\.0-9]+$";"sed -r 's/signver[
 siprotec_5;;proprietary;"FWAOS_V[0-9]+.[0-9]+.[0-9]+.[0-9]+$";"sed -r 's/FWAOS_V([0-9]+(\.[0-9]+)+?)$/siprotec_5:\1/'";
 sicam;;proprietary;"7KG[0-9][0-9]x\ V[0-9]+(\.[0-9]+)+?\ PCK\ FILE$";"sed -r 's/7KG[0-9][0-9]x\ V([0-9]+(\.[0-9]+)+?)\ PCK\ FILE/sicam_q100:\1/'";
 #sisco_mms_lite;;unknown;"MMS-LITE-80X-001";"NA";
-smbd;strict;gplv3;"^[2-5]\.[0-9]+\.[0-9]+$";"sed -r 's/([0-9](\.[0-9]+)+?)$/samba:\1/'";
+smbd;multi_grep;gplv3;'"^smbd version %s started.$"&&"^[2-5]\.[0-9]+\.[0-9]+$"';"sed -r 's/([0-9](\.[0-9]+)+?)$/samba:\1/'";
 smbd;strict;gplv3;"^Version\ [2-5]\.[0-9]+\.[0-9]+$";"sed -r 's/Version\ ([0-9](\.[0-9]+)+?)$/samba:\1/'";
 smbd;strict;gplv3;"^Version\ [2-5]\.[0-9]+\.[0-9]+[a-z]$";"sed -r 's/Version\ ([0-9](\.[0-9]+)+?[a-z]?)$/samba:\1/'";
 smbftpd;;unknown;"^SmbFTPD\ Ver\ [0-9]\.[0-9]+$";"sed -r 's/SmbFTPD\ Ver\ ([0-9](\.[0-9]+)+?)$/smbftpd:\1/'";

--- a/config/bin_version_strings.cfg
+++ b/config/bin_version_strings.cfg
@@ -741,6 +741,7 @@ wpa_cli;;bsd;"wpa_cli\ v[0-9](\.[0-9]+)+?\.x$";"sed -r 's/wpa_cli\ v([0-9](\.[0-
 wpa_supplicant;;bsd;"^wpa_supplicant\ v[0-9](\.[0-9]+)+?(-devel)?$";"sed -r 's/wpa_supplicant\ v([0-9](\.[0-9]+)+?).*/wpa_supplicant:\1/'";
 wpa_supplicant;;bsd;"^wpa_supplicant\ v[0-9](\.[0-9]+)+?\.x$";"sed -r 's/wpa_supplicant\ v([0-9](\.[0-9]+)+?).*/wpa_supplicant:\1/'";
 wps_enr;strict;unknown;"^Version:\ [0-9](\.[0-9]+)+?$";"sed -r 's/Version:\ ([0-9](\.[0-9]+)+?)$/wps_enr:\1/'";
+xargs;multi_grep;gplv3;'"^xargs$"&&"^environment\ is\ too\ large\ for\ exec$"&&"[0-9](\.[0-9]+)+?"';"sed -r 's/([0-9](\.[0-9]+)+?)/xargs:\1/'";
 xdb_70_monitor;;unknown;"^\*\*\*\*\ \ XDB\ 70\ Monitor\ V\ [0-9]+\.[0-9]+\ \(.*\),\ Copyright\ \(C\)\ SIEMENS\ AG\ [0-9]+\.\ All\ rights\ reserved\.\ \*\*\*\*$";"sed -r 's/\*\*\*\*\ \ XDB\ 70\ Monitor\ V\ ([0-9](\.[0-9]+)+?)$/siemens:xdb-monitor:\1/'";
 xfsprogs;;unknown;"^mkfs\.xfs\ version\ [0-9](\.[0-9]+)+?$";"sed -r 's/mkfs\.xfs\ version\ ([0-9](\.[0-9]+)+?)$/xfsprogs:\1/'";
 xfsprogs;;unknown;"^xfs_db\ version\ [0-9](\.[0-9]+)+?$";"sed -r 's/xfs_db\ version\ ([0-9](\.[0-9]+)+?)$/xfsprogs:\1/'";

--- a/config/bin_version_strings.cfg
+++ b/config/bin_version_strings.cfg
@@ -14,10 +14,11 @@
 # Description: Version database for detection of binary versions via emulation and static analysis
 #
 # example:
-# identifier;strict/zgrep;license;version identifier regex;version transformation regex/NA;
+# identifier;strict/zgrep/multi_grep;license;version identifier regex;version transformation regex/NA;
 # strict -> only use this regex on files with the name of the identifier
 # no_static -> typically this rule produces false positives in static analysis -> only use this rule in emulation mode
 # zgrep -> find file named in the identifier field, executes zgrep on the file(s) with the "version identifier" field as search string -> early alpha state!
+# multi_grep -> multiple identifiers are checked
 # live -> version identifier found via live tester modules
 # license -> unknown/gpl/gplv2/gplv3/mit/proprietary
 # version transformation regex -> the regex needed to transform the version for the cve-database request / NA if not available
@@ -347,6 +348,7 @@ libpng;;libpng;"libpng\ version\ [0-9](\.[0-9]+)+?\ ";"sed -r 's/libpng\ version
 libreswan;;gplv2;"^Libreswan\ [\.0-9]+";"sed -r 's/Libreswan\ ([0-9](\.[0-9]+)+?).*/libreswan:\1/'";
 libsensors;;unknown;"libsensors\ version\ [\.0-9]+$";"sed -r 's/libsensors\ version\ ([0-9](\.[0-9]+)+?)$/libsensors:\1/'";
 libtiff;;unknown;"^LIBTIFF,\ Version\ [0-9](\.[0-9]+)+?$";"sed -r 's/LIBTIFF,\ Version\ ([0-9](\.[0-9]+)+?)$/libtiff:libtiff:\1/'";
+libtasn;multi_grep;unknown;'"LIBTASN1 ERROR:"&&"^[0-9](\.[0-9]+)?+$"';"sed -r 's/([0-9](\.[0-9]+)+?)$/libtasn1:\1/'";
 lighttpd;;bsd;"^lighttpd\/[0-9](\.[0-9]+)+?\ .*\ -\ a\ light\ and\ fast\ webserver$";"sed -r 's/lighttpd\/([0-9](\.[0-9]+)+?)\ .*/lighttpd:\1/'";
 lighttpd;live;bsd;"^lighttpd\/[0-9](\.[0-9]+)+?(-devel-[0-9]+[A-Z])?$";"sed -r 's/lighttpd\/([0-9](\.[0-9]+)+?).*/lighttpd:\1/'";
 lighttpd;;bsd;"^lighttpd-[0-9](\.[0-9]+)+?\ \-\ a\ light\ and\ fast\ webserver$";"sed -r 's/lighttpd-([0-9](\.[0-9]+)+?)\ .*/lighttpd:\1/'";

--- a/config/bin_version_strings.cfg
+++ b/config/bin_version_strings.cfg
@@ -15,7 +15,7 @@
 #
 # example:
 # identifier;strict/zgrep/multi_grep;license;version identifier regex;version transformation regex/NA;
-# strict -> only use this regex on files with the name of the identifier
+# strict -> only use this regex on files with the name of the identifier (Warning: Strict mode is deprecated)
 # no_static -> typically this rule produces false positives in static analysis -> only use this rule in emulation mode
 # zgrep -> find file named in the identifier field, executes zgrep on the file(s) with the "version identifier" field as search string -> early alpha state!
 # multi_grep -> multiple identifiers are checked. These identifiers need to be in the format '"IDENTIFIER1"&&"IDENTIFIER2"&&"IDENTIFIER3"'. The last identifier needs to be the

--- a/helpers/helpers_emba_defaults.sh
+++ b/helpers/helpers_emba_defaults.sh
@@ -135,4 +135,5 @@ set_defaults() {
   TOTAL_MEMORY="$(grep MemTotal /proc/meminfo | awk '{print $2}' || true)"
   export Q_MOD_PID=""
   export F20_DEEP=1      # F20 module - set to cve-discovery caller for further processing
+  export UEFI_VERIFIED=0
 }

--- a/modules/F20_vul_aggregator.sh
+++ b/modules/F20_vul_aggregator.sh
@@ -807,7 +807,7 @@ check_kernel_major_v() {
   if [[ "${lBIN_VERSION_ONLY:0:1}" != "${lKERNEL_CVE_VER:0:1}" ]]; then
     # print_output is for printing to cli
     # write_log is for writing the needed log file
-    local OUT_MESSAGE="[-] Info for CVE ${ORANGE}${lCVE_ID}${NC} - Major kernel version not matching ${ORANGE}${lKERNEL_CVE_VER}${NC} vs ${ORANGE}${lBIN_VERSION_ONLY}${NC} - Higher false positive risk" "no_log"
+    local OUT_MESSAGE="[-] Info for CVE ${ORANGE}${lCVE_ID}${NC} - Major kernel version not matching ${ORANGE}${lKERNEL_CVE_VER}${NC} vs ${ORANGE}${lBIN_VERSION_ONLY}${NC} - Higher false positive risk"
     print_output "${OUT_MESSAGE}" "no_log"
     write_log "${OUT_MESSAGE}" "${LOG_PATH_MODULE}/kernel_cve_version_issues.log"
   fi

--- a/modules/F20_vul_aggregator.sh
+++ b/modules/F20_vul_aggregator.sh
@@ -25,7 +25,6 @@ F20_vul_aggregator() {
 
   # we use this for later decisions:
   export F20_DEEP=1
-  print_ln
 
   prepare_cve_search_module
 
@@ -442,7 +441,9 @@ generate_cve_details_cves() {
     fi
   done
 
-  [[ "${THREADED}" -eq 1 ]] && wait_for_pid "${WAIT_PIDS_F19[@]}"
+  if [[ "${THREADED}" -eq 1 ]]; then
+    wait_for_pid "${WAIT_PIDS_F19[@]}"
+  fi
 }
 
 generate_cve_details_versions() {
@@ -464,7 +465,9 @@ generate_cve_details_versions() {
     fi
   done
 
-  [[ "${THREADED}" -eq 1 ]] && wait_for_pid "${WAIT_PIDS_F19[@]}"
+  if [[ "${THREADED}" -eq 1 ]]; then
+    wait_for_pid "${WAIT_PIDS_F19[@]}"
+  fi
 }
 
 cve_db_lookup_cve() {
@@ -802,7 +805,11 @@ check_kernel_major_v() {
   local lKERNEL_CVE_VER="${2:-}"
   local lCVE_ID="${3:-}"
   if [[ "${lBIN_VERSION_ONLY:0:1}" != "${lKERNEL_CVE_VER:0:1}" ]]; then
-    print_output "[-] Info for CVE ${ORANGE}${lCVE_ID}${NC} - Major kernel version not matching ${ORANGE}${lKERNEL_CVE_VER}${NC} vs ${ORANGE}${lBIN_VERSION_ONLY}${NC} - Higher false positive risk" "no_log"
+    # print_output is for printing to cli
+    # write_log is for writing the needed log file
+    local OUT_MESSAGE="[-] Info for CVE ${ORANGE}${lCVE_ID}${NC} - Major kernel version not matching ${ORANGE}${lKERNEL_CVE_VER}${NC} vs ${ORANGE}${lBIN_VERSION_ONLY}${NC} - Higher false positive risk" "no_log"
+    print_output "${OUT_MESSAGE}" "no_log"
+    write_log "${OUT_MESSAGE}" "${LOG_PATH_MODULE}/kernel_cve_version_issues.log"
   fi
 }
 

--- a/modules/F50_base_aggregator.sh
+++ b/modules/F50_base_aggregator.sh
@@ -133,7 +133,7 @@ output_overview() {
   fi
 
   if [[ -n "${ARCH}" ]]; then
-    if [[ -n "${D_END}" ]]; then
+    if [[ -n "${D_END:-"NA"}" ]]; then
       write_csv_log "architecture_verified" "${ARCH}" "${D_END}" "NA" "NA" "NA" "NA" "NA" "NA"
       print_output "[+] Detected architecture and endianness (""${ORANGE}""verified${GREEN}):""${ORANGE}"" ""${ARCH}"" / ""${D_END}""${NC}"
     else
@@ -142,7 +142,7 @@ output_overview() {
     fi
     write_link "p99"
   elif [[ -f "${P99_CSV_LOG}" ]] && [[ -n "${P99_ARCH}" ]]; then
-    if [[ -n "${D_END}" ]]; then
+    if [[ -n "${D_END:-"NA"}" ]]; then
       write_csv_log "architecture_verified" "${P99_ARCH}" "${P99_ARCH_END}" "NA" "NA" "NA" "NA" "NA" "NA"
       print_output "[+] Detected architecture and endianness (""${ORANGE}""verified${GREEN}):""${ORANGE}"" ""${P99_ARCH}"" / ""${P99_ARCH_END}""${NC}"
     else

--- a/modules/P99_prepare_analyzer.sh
+++ b/modules/P99_prepare_analyzer.sh
@@ -82,7 +82,7 @@ P99_prepare_analyzer() {
       UNIQUE_FILES=$(find "${ROOT_PATH}" "${EXCL_FIND[@]}" -xdev -type f -exec md5sum {} \; 2>/dev/null | sort -u -k1,1 | cut -d\  -f3 | wc -l )
       DIRS_EXT=$(find "${ROOT_PATH}" -xdev -type d | wc -l )
       BINS=$(find "${ROOT_PATH}" "${EXCL_FIND[@]}" -xdev -type f -exec file {} \; | grep -c "ELF" || true)
-      write_csv_log "${FILES_EXT}" "${UNIQUE_FILES}" "${DIRS_EXT}" "${BINS}" "${LINUX_PATH_COUNTER}" "${R_PATH}" "${ARCH}" "${D_END}"
+      write_csv_log "${FILES_EXT}" "${UNIQUE_FILES}" "${DIRS_EXT}" "${BINS}" "${LINUX_PATH_COUNTER}" "${R_PATH}" "${ARCH}" "${D_END:-"NA"}"
     done
   fi
 

--- a/modules/S09_firmware_base_version_check.sh
+++ b/modules/S09_firmware_base_version_check.sh
@@ -57,7 +57,6 @@ S09_firmware_base_version_check() {
     VERSION_IDENTIFIER="$(safe_echo "${VERSION_LINE}" | cut -d\; -f4)"
     VERSION_IDENTIFIER="${VERSION_IDENTIFIER/\"}"
     VERSION_IDENTIFIER="${VERSION_IDENTIFIER%\"}"
-    print_output "[*] Found VERSION_IDENTIFIER: ${VERSION_IDENTIFIER}"
 
     if [[ "${STRICT}" == *"strict"* ]]; then
 

--- a/modules/S09_firmware_base_version_check.sh
+++ b/modules/S09_firmware_base_version_check.sh
@@ -197,7 +197,7 @@ bin_string_checker() {
         if [[ "${BIN_FILE}" == *ELF* ]] ; then
           VERSION_FINDER=$(strings "${BIN}" | grep -o -a -E "${VERSION_IDENTIFIER}" | head -1 2> /dev/null || true)
           if [[ -n ${VERSION_FINDER} ]]; then
-            if [[ "${#VERSION_IDENTIFIERS_ARR[@]}" -gt 1 ]] && [[ "$((${j}+1))" -lt "${#VERSION_IDENTIFIERS_ARR[@]}" ]]; then
+            if [[ "${#VERSION_IDENTIFIERS_ARR[@]}" -gt 1 ]] && [[ "$((j+1))" -lt "${#VERSION_IDENTIFIERS_ARR[@]}" ]]; then
               # we found the first identifier and now we need to check the other identifiers also
               print_output "[+] Found sub identifier ${ORANGE}${VERSION_IDENTIFIER}${GREEN} in binary ${ORANGE}${BIN}${GREEN}" "no_log"
               continue

--- a/modules/S09_firmware_base_version_check.sh
+++ b/modules/S09_firmware_base_version_check.sh
@@ -13,9 +13,10 @@
 #
 # Author(s): Michael Messner, Pascal Eckmann
 
-# Description:  Iterates through a static list with version details layout
+# Description:  Iterates through a list with regex identifiers of version details
 #               (e.g. busybox:binary:"BusyBox\ v[0-9]\.[0-9][0-9]\.[0-9]\ .*\ multi-call\ binary" ) of all executables and
 #               checks if these fit on a binary in the firmware.
+#               The version configuration file is stored in config/bin_version_strings.cfg
 
 # Threading priority - if set to 1, these modules will be executed first
 export THREAD_PRIO=1
@@ -29,7 +30,7 @@ S09_firmware_base_version_check() {
   module_title "Static binary firmware versions detection"
   pre_module_reporter "${FUNCNAME[0]}"
 
-  EXTRACTOR_LOG="${LOG_DIR}"/p60_firmware_bin_extractor.txt
+  EXTRACTOR_LOG="${LOG_DIR}"/p55_unblob_extractor/unblob_firmware.log
 
   print_output "[*] Static version detection running ..." "no_log" | tr -d "\n"
   write_csv_log "binary/file" "version_rule" "version_detected" "csv_rule" "license" "static/emulation"
@@ -53,7 +54,15 @@ S09_firmware_base_version_check() {
     BIN_NAME="$(safe_echo "${VERSION_LINE}" | cut -d\; -f1)"
     CSV_REGEX="$(echo "${VERSION_LINE}" | cut -d\; -f5)"
 
-    # VERSION_IDENTIFIER="$(echo "${VERSION_LINE}" | cut -d\; -f4 | sed s/^\"// | sed s/\"$//)"
+    if [[ -f "${CSV_DIR}"/s09_firmware_base_version_check.csv ]]; then
+      # this should prevent double checking - if a version identifier was already successful we do not need to
+      # test the other identifiers. In threaded mode this usually does not decrease testing speed.
+      if [[ "$(tail -n +2 "${CSV_DIR}"/s09_firmware_base_version_check.csv | cut -d\; -f2 | grep -c "^${BIN_NAME}$")" -gt 0 ]]; then
+        print_output "[*] Already identified component for identifier ${BIN_NAME} - ${CSV_REGEX} ... skipping further tests" "no_log"
+        continue
+      fi
+    fi
+
     VERSION_IDENTIFIER="$(safe_echo "${VERSION_LINE}" | cut -d\; -f4)"
     VERSION_IDENTIFIER="${VERSION_IDENTIFIER/\"}"
     VERSION_IDENTIFIER="${VERSION_IDENTIFIER%\"}"
@@ -62,6 +71,7 @@ S09_firmware_base_version_check() {
 
       # strict mode
       #   use the defined regex only on a binary called BIN_NAME (field 1)
+      #   Warning: strict mode is deprecated and will be removed in the future.
 
       [[ "${RTOS}" -eq 1 ]] && continue
 
@@ -72,7 +82,7 @@ S09_firmware_base_version_check() {
           VERSION_FINDER=$(strings "${BIN}" | grep -E "${VERSION_IDENTIFIER}" | sort -u || true)
           if [[ -n ${VERSION_FINDER} ]]; then
             print_ln "no_log"
-            print_output "[+] Version information found ${RED}${BIN_NAME} ${VERSION_FINDER}${NC}${GREEN} in binary ${ORANGE}$(print_path "${BIN}")${GREEN} (license: ${ORANGE}${LIC}${GREEN}) (${ORANGE}static - strict${GREEN})."
+            print_output "[+] Version information found ${RED}${BIN_NAME} ${VERSION_FINDER}${NC}${GREEN} in binary ${ORANGE}$(print_path "${BIN}")${GREEN} (license: ${ORANGE}${LIC}${GREEN}) (${ORANGE}static - strict - deprecated${GREEN})."
             get_csv_rule "${VERSION_FINDER}" "${CSV_REGEX}"
             write_csv_log "${BIN}" "${BIN_NAME}" "${VERSION_FINDER}" "${CSV_RULE}" "${LIC}" "${TYPE}"
             continue
@@ -107,14 +117,16 @@ S09_firmware_base_version_check() {
 
       # This is default mode!
 
-      # check binwalk files sometimes we can find kernel version information or something else in it
-      VERSION_FINDER=$(grep -o -a -E "${VERSION_IDENTIFIER}" "${EXTRACTOR_LOG}" 2>/dev/null | head -1 2>/dev/null || true)
-      if [[ -n ${VERSION_FINDER} ]]; then
-        print_ln "no_log"
-        print_output "[+] Version information found ${RED}""${VERSION_FINDER}""${NC}${GREEN} in binwalk logs (license: ${ORANGE}${LIC}${GREEN}) (${ORANGE}static${GREEN})."
-        get_csv_rule "${VERSION_FINDER}" "${CSV_REGEX}"
-        write_csv_log "binwalk logs" "${BIN_NAME}" "${VERSION_FINDER}" "${CSV_RULE}" "${LIC}" "${TYPE}"
-        print_dot
+      if [[ -f "${EXTRACTOR_LOG}" ]]; then
+        # check unblob files sometimes we can find kernel version information or something else in it
+        VERSION_FINDER=$(grep -o -a -E "${VERSION_IDENTIFIER}" "${EXTRACTOR_LOG}" 2>/dev/null | head -1 2>/dev/null || true)
+        if [[ -n ${VERSION_FINDER} ]]; then
+          print_ln "no_log"
+          print_output "[+] Version information found ${RED}""${VERSION_FINDER}""${NC}${GREEN} in unblob logs (license: ${ORANGE}${LIC}${GREEN}) (${ORANGE}static${GREEN})."
+          get_csv_rule "${VERSION_FINDER}" "${CSV_REGEX}"
+          write_csv_log "unblob logs" "${BIN_NAME}" "${VERSION_FINDER}" "${CSV_RULE}" "${LIC}" "${TYPE}"
+          print_dot
+        fi
       fi
 
       print_dot

--- a/modules/S116_qemu_version_detection.sh
+++ b/modules/S116_qemu_version_detection.sh
@@ -67,6 +67,10 @@ version_detection_thread() {
   BINARY="$(echo "${VERSION_LINE}" | cut -d\; -f1)"
   local STRICT=""
   STRICT="$(echo "${VERSION_LINE}" | cut -d\; -f2)"
+  if [[ ${STRICT} == "multi_grep" ]]; then
+    print_output "[-] Multi grep version identifiers currently not available in emulation module"
+    return
+  fi
   local LIC=""
   LIC="$(echo "${VERSION_LINE}" | cut -d\; -f3)"
   local CSV_REGEX=""

--- a/modules/S116_qemu_version_detection.sh
+++ b/modules/S116_qemu_version_detection.sh
@@ -38,6 +38,16 @@ S116_qemu_version_detection() {
         if echo "${VERSION_LINE}" | grep -v -q "^[^#*/;]"; then
           continue
         fi
+        if [[ -f "${CSV_DIR}"/s116_qemu_version_detection.csv ]]; then
+          # this should prevent double checking - if a version identifier was already successful we do not need to
+          # test the other identifiers. In threaded mode this usually does not decrease testing speed
+          local BINARY=""
+          BINARY="$(echo "${VERSION_LINE}" | cut -d\; -f1)"
+          if [[ "$(tail -n +2 "${CSV_DIR}"/s116_qemu_version_detection.csv | cut -d\; -f2 | grep -c "^${BINARY}$")" -gt 0 ]]; then
+            print_output "[*] Already identified component for identifier ${ORANGE}${BINARY}${NC} ... skipping further tests" "no_log"
+            continue
+          fi
+        fi
 
         if [[ ${THREADED} -eq 1 ]]; then
           version_detection_thread "${VERSION_LINE}" &
@@ -67,14 +77,15 @@ version_detection_thread() {
   BINARY="$(echo "${VERSION_LINE}" | cut -d\; -f1)"
   local STRICT=""
   STRICT="$(echo "${VERSION_LINE}" | cut -d\; -f2)"
-  if [[ ${STRICT} == "multi_grep" ]]; then
-    print_output "[-] Multi grep version identifiers currently not available in emulation module"
-    return
-  fi
   local LIC=""
   LIC="$(echo "${VERSION_LINE}" | cut -d\; -f3)"
   local CSV_REGEX=""
   CSV_REGEX="$(echo "${VERSION_LINE}" | cut -d\; -f5)"
+
+  if [[ ${STRICT} == "multi_grep" ]]; then
+    print_output "[-] Multi grep version identifier for ${ORANGE}${CSV_REGEX}${NC} currently not supported in emulation module" "no_log"
+    return
+  fi
 
   local VERSION_IDENTIFIER=""
   # VERSION_IDENTIFIER="$(echo "${VERSION_LINE}" | cut -d\; -f4 | sed s/^\"// | sed s/\"$//)"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

see https://github.com/e-m-b-a/emba/issues/980

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

closes https://github.com/e-m-b-a/emba/issues/980

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Yea ... we can not define more complex version identifier rules :)

```
libtasn;multi_grep;unknown;'"LIBTASN1 ERROR:"&&"^[0-9](\.[0-9]+)?+$"';"sed -r 's/([0-9](\.[0-9]+)+?)$/libtasn1:\1/'";
```
Module s09 now checks first for `LIBTASN1 ERROR:` and if this is found it checks for the second identifier `^[0-9](\.[0-9]+)?+$` 

* **Other information**:

This PR is work in progress and needs some more testing ...