### PR TITLE
Remove printing of every single log file which could take a very long…

### DIFF
--- a/helpers/helpers_emba_prepare.sh
+++ b/helpers/helpers_emba_prepare.sh
@@ -113,9 +113,6 @@ log_folder()
   if [[ ${USE_DOCKER} -eq 1 && ${#D_LOG_FILES[@]} -gt 0 ]] ; then
     echo -e "\\n[${RED}!${NC}] ${ORANGE}Warning${NC}\\n"
     echo -e "    It appears that there are log files in the EMBA directory.\\n    You should move these files to another location where they won't be exposed to the Docker container."
-    for D_LOG_FILE in "${D_LOG_FILES[@]}" ; do
-      echo -e "        ""$(print_path "${D_LOG_FILE}")"
-    done
     echo -e "\\n${ORANGE}Continue to run EMBA and ignore this warning?${NC}\\n"
     read -p "(Y/n)  " -r ANSWER
     case ${ANSWER:0:1} in

--- a/helpers/helpers_emba_prepare.sh
+++ b/helpers/helpers_emba_prepare.sh
@@ -109,10 +109,13 @@ log_folder()
     esac
   fi
 
-  readarray -t D_LOG_FILES < <( find . \( -path ./external -o -path ./config -o -path ./licenses -o -path ./tools \) -prune -false -o \( -name "*.txt" -o -name "*.log" \) -exec md5sum {} \; 2>/dev/null | sort -u -k1,1 | cut -d\  -f3 )
+  readarray -t D_LOG_FILES < <( find . \( -path ./external -o -path ./config -o -path ./licenses -o -path ./tools \) -prune -false -o \( -name "*.txt" -o -name "*.log" \) | head -100 )
   if [[ ${USE_DOCKER} -eq 1 && ${#D_LOG_FILES[@]} -gt 0 ]] ; then
     echo -e "\\n[${RED}!${NC}] ${ORANGE}Warning${NC}\\n"
     echo -e "    It appears that there are log files in the EMBA directory.\\n    You should move these files to another location where they won't be exposed to the Docker container."
+    for D_LOG_FILE in "${D_LOG_FILES[@]}" ; do
+      echo -e "        ""$(orange "${D_LOG_FILE}")"
+    done
     echo -e "\\n${ORANGE}Continue to run EMBA and ignore this warning?${NC}\\n"
     read -p "(Y/n)  " -r ANSWER
     case ${ANSWER:0:1} in

--- a/modules/P10_vmdk_extractor.sh
+++ b/modules/P10_vmdk_extractor.sh
@@ -86,7 +86,7 @@ vmdk_extractor() {
     if mount | grep -q vmdk_mount; then
       print_output "[*] Copying ${ORANGE}${MOUNT_DEV}${NC} to firmware directory ${ORANGE}${EXTRACTION_DIR_}/${DEV_NAME}${NC}"
       mkdir -p "${EXTRACTION_DIR_}"/"${DEV_NAME}"/ || true
-      cp -pri "${TMP_VMDK_MNT}"/* "${EXTRACTION_DIR_}"/"${DEV_NAME}"/ || true
+      cp -pr "${TMP_VMDK_MNT}"/* "${EXTRACTION_DIR_}"/"${DEV_NAME}"/ || true
       umount "${TMP_VMDK_MNT}"
     fi
   done


### PR DESCRIPTION
… time

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Remove printing every leftover file, which takes a significant amount of time

* **What is the current behavior?** (You can also link to an open issue here)

EMBA prints every single file, which takes forever, making me quit EMBA

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

There is no point in printing every single file anyway, if a user wants to know the permissions and files they should be able to execute a command themselves.

It also indirectly solves the problem that this check is done at all during a scan resume. While it is still done (which it shouldn't because obviously there are log files when we resume from those), it is not blocking the entire resume by taking a long time to print file lists.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
