### PR TITLE
Fix to prevent the detection of binaries not beeing present in the firmware

### DIFF
--- a/modules/S09_firmware_base_version_check.sh
+++ b/modules/S09_firmware_base_version_check.sh
@@ -310,7 +310,7 @@ bin_string_checker() {
 
         if [[ "${BIN_FILE}" == *ELF* ]] ; then
           # print_output "[*] Testing $BIN with version identifier ${VERSION_IDENTIFIER}" "no_log"
-          VERSION_FINDER=$(grep -o -a -E "${VERSION_IDENTIFIER}" "${STRINGS_OUTPUT}" | sort -u | head -1 || true)
+          VERSION_FINDER=$(grep -o -a -E "^${VERSION_IDENTIFIER}" "${STRINGS_OUTPUT}" | sort -u | head -1 || true)
 
           if [[ -n ${VERSION_FINDER} ]]; then
             if [[ "${#VERSION_IDENTIFIERS_ARR[@]}" -gt 1 ]] && [[ "$((j+1))" -lt "${#VERSION_IDENTIFIERS_ARR[@]}" ]]; then


### PR DESCRIPTION
S09_firmware_base_version_check.sh incorrectly detects multiple binaries, not present in the firmware.

Forcing the binary name (${VERSION_IDENTIFIER}) to be present at the start of the dumped strings, instead of anywhere inside, removes a lot of incorrectly detected binaries, while preserving all the correctly detected ones. 

The fix corrects for example the wrong detection on OpenSSL 1.1.1a, even if it's not present in the firmware.

![Capture d’écran du 2024-04-22 11-12-39](https://github.com/e-m-b-a/emba/assets/68375008/20b3a402-07bc-4d49-bbe5-6782a3c2312e)
