### PR TITLE
Version string fixes for isc:dhcp and gnu:glibc

### DIFF
--- a/config/bin_version_strings.cfg
+++ b/config/bin_version_strings.cfg
@@ -295,10 +295,10 @@ iptunnel;;unknown;"iptunnel\ [0-9](\.[0-9]+)+?";"sed -r 's/iptunnel\ ([0-9](\.[0
 ipunz;;commercial;"^ipunz V[0-9]\.[0-9]$";"sed -r 's/ipunz\ V([0-9](\.[0-9]+)+?)$/ipcomm:ipunz:\1/'";
 ipzip;;commercial;"^ipzip V[0-9]\.[0-9]$";"sed -r 's/ipzip\ V([0-9](\.[0-9]+)+?)$/ipcomm:ipzip:\1/'";
 iputils;;unknown;"iputils-s{,3}[0-9]+";"sed -r 's/iputils-s{,3}([0-9]+)$/iputils:\1/'";
-isc-dhclient;;ISC;"Internet\ Systems\ Consortium\ DHCP\ Client\ [0-9](\.[0-9]+)+?([a-z][0-9])?$";"sed -r 's/Internet\ Systems\ Consortium\ DHCP\ Client\ ([0-9](\.[0-9]+)+?([a-z][0-9])?)$/isc:dhcp:\1/'";
-isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?)$/isc:dhcp:\1/'";
-isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?-([ABPabp]|rc|RC)[0-3]$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?(-([ABPabp]|rc|RC)[0-3])?)$/isc:dhcp:\1/'";
-isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?-ESV-R[0-9]$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?(-ESV-R[0-9])?)$/isc:dhcp:\1/'";
+isc-dhclient;;ISC;"Internet\ Systems\ Consortium\ DHCP\ Client\ [0-9](\.[0-9]+)+?([a-z][0-9])?$";"sed -r 's/Internet\ Systems\ Consortium\ DHCP\ Client\ ([0-9](\.[0-9]+)+?([a-z][0-9])?)$/isc:dhcp_client:\1/'";
+isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?)$/isc:dhcp_client:\1/'";
+isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?-([ABPabp]|rc|RC)[0-3]$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?(-([ABPabp]|rc|RC)[0-3])?)$/isc:dhcp_client:\1/'";
+isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?-ESV-R[0-9]$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?(-ESV-R[0-9])?)$/isc:dhcp_client:\1/'";
 ischroot;;unknown;"ischroot,\ version\ [0-9](\.[0-9]+)+?";"sed -r 's/ischroot,\ version\ ([0-9](\.[0-9]+)+?).*/ischroot:\1/'";
 isisd;;unknown;"^ISISd\ version\ [0-9]+(\.[0-9]+)+?$";"sed -r 's/ISISd\ version\ ([0-9]+(\.[0-9]+)+?)$/isisd:\1/'";
 iwconfig;;unknown;"iwconfig\ \ Version\ [0-9]+$";"sed -r 's/iwconfig(\ )+Version\ ([0-9]+)$/wireless_tools:\2/'";

--- a/config/bin_version_strings.cfg
+++ b/config/bin_version_strings.cfg
@@ -295,10 +295,10 @@ iptunnel;;unknown;"iptunnel\ [0-9](\.[0-9]+)+?";"sed -r 's/iptunnel\ ([0-9](\.[0
 ipunz;;commercial;"^ipunz V[0-9]\.[0-9]$";"sed -r 's/ipunz\ V([0-9](\.[0-9]+)+?)$/ipcomm:ipunz:\1/'";
 ipzip;;commercial;"^ipzip V[0-9]\.[0-9]$";"sed -r 's/ipzip\ V([0-9](\.[0-9]+)+?)$/ipcomm:ipzip:\1/'";
 iputils;;unknown;"iputils-s{,3}[0-9]+";"sed -r 's/iputils-s{,3}([0-9]+)$/iputils:\1/'";
-isc-dhclient;;ISC;"Internet\ Systems\ Consortium\ DHCP\ Client\ [0-9](\.[0-9]+)+?([a-z][0-9])?$";"sed -r 's/Internet\ Systems\ Consortium\ DHCP\ Client\ ([0-9](\.[0-9]+)+?([a-z][0-9])?)$/isc:dhcp_client:\1/'";
-isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?)$/isc:dhcp_client:\1/'";
-isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?-([ABPabp]|rc|RC)[0-3]$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?(-([ABPabp]|rc|RC)[0-3])?)$/isc:dhcp_client:\1/'";
-isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?-ESV-R[0-9]$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?(-ESV-R[0-9])?)$/isc:dhcp_client:\1/'";
+isc-dhclient;;ISC;"Internet\ Systems\ Consortium\ DHCP\ Client\ [0-9](\.[0-9]+)+?([a-z][0-9])?$";"sed -r 's/Internet\ Systems\ Consortium\ DHCP\ Client\ ([0-9](\.[0-9]+)+?([a-z][0-9])?)$/isc:dhcp:\1/'";
+isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?)$/isc:dhcp:\1/'";
+isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?-([ABPabp]|rc|RC)[0-3]$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?(-([ABPabp]|rc|RC)[0-3])?)$/isc:dhcp:\1/'";
+isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?-ESV-R[0-9]$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?(-ESV-R[0-9])?)$/isc:dhcp:\1/'";
 ischroot;;unknown;"ischroot,\ version\ [0-9](\.[0-9]+)+?";"sed -r 's/ischroot,\ version\ ([0-9](\.[0-9]+)+?).*/ischroot:\1/'";
 isisd;;unknown;"^ISISd\ version\ [0-9]+(\.[0-9]+)+?$";"sed -r 's/ISISd\ version\ ([0-9]+(\.[0-9]+)+?)$/isisd:\1/'";
 iwconfig;;unknown;"iwconfig\ \ Version\ [0-9]+$";"sed -r 's/iwconfig(\ )+Version\ ([0-9]+)$/wireless_tools:\2/'";

--- a/config/bin_version_strings.cfg
+++ b/config/bin_version_strings.cfg
@@ -213,7 +213,7 @@ glibc;;LGPL-2.1-or-later;"GNU\ C\ Library\ \(GLIBC\)\ stable\ release\ version\ 
 glibc;;LGPL-2.1-or-later;"GNU\ C\ Library\ stable\ release\ version\ [0-9](\.[0-9]+)+?,\ ";"sed -r 's/GNU\ C\ Library\ stable\ release\ version\ ([0-9](\.[0-9]+)+?),\ .*/gnu:glibc:\1/'";
 glibc;;LGPL-2.1-or-later;"ldconfig\ \(GNU\ libc\)\ [0-9](\.[0-9]+)+?$";"sed -r 's/ldconfig\ \(GNU\ libc\)\ ([0-9](\.[0-9]+)+?)$/gnu:glibc:\1/'";
 glibc;;LGPL-2.1-or-later;"GNU\ C\ Library\ development\ release\ version\ [0-9](\.[0-9]+)+?$";"sed -r 's/GNU\ C\ Library\ development\ release\ version\ ([0-9](\.[0-9]+)+?)$/gnu:glibc:\1/'";
-glibc;;LGPL-2.1-or-later;"GNU\ C\ Library\ \(.*\)\ stable\ release\ version\ [0-9](\.[0-9]+)+?(\.)?$";"sed -r 's/GNU\ C\ Library\ \(.*\)\ stable\ release\ version\ ([0-9](\.[0-9]+)+?)$/gnu:glibc:\1/'";
+glibc;;LGPL-2.1-or-later;"GNU\ C\ Library\ \(.*\)\ stable\ release\ version\ [0-9](\.[0-9]+)+?(\.)?$";"sed -r 's/GNU\ C\ Library\ \(.*\)\ stable\ release\ version\ ([0-9](\.[0-9]+)+?)(\.)?$/gnu:glibc:\1/'";
 gnu_cpio;;GPL-3.0-only;"\(GNU\ cpio\)\ [0-9](\.[0-9]+)+?$";"sed -r 's/\(GNU\ cpio\)\ ([0-9](\.[0-9]+)+?)$/gnu:cpio:\1/'";
 gnu_findutils;;GPL-3.0-only;"\(GNU\ findutils\)\ [0-9](\.[0-9]+)+?$";"sed -r 's/\(GNU\ findutils\)\ ([0-9](\.[0-9]+)+?)$/gnu:findutils:\1/'";
 gnu_findutils;;GPL-3.0-only;"\(GNU\ findutils\)\ [0-9](\.[0-9]+)+?-[a-z]+$";"sed -r 's/\(GNU\ findutils\)\ ([0-9](\.[0-9]+)+?-[a-z]+)$/gnu:findutils:\1/'";

--- a/config/bin_version_strings_quick.cfg
+++ b/config/bin_version_strings_quick.cfg
@@ -113,7 +113,7 @@ glibc;;LGPL-2.1-or-later;"GNU\ C\ Library\ \(GLIBC\)\ stable\ release\ version\ 
 glibc;;LGPL-2.1-or-later;"GNU\ C\ Library\ stable\ release\ version\ [0-9](\.[0-9]+)+?,\ ";"sed -r 's/GNU\ C\ Library\ stable\ release\ version\ ([0-9](\.[0-9]+)+?),\ .*/gnu:glibc:\1/'";
 glibc;;LGPL-2.1-or-later;"ldconfig\ \(GNU\ libc\)\ [0-9](\.[0-9]+)+?$";"sed -r 's/ldconfig\ \(GNU\ libc\)\ ([0-9](\.[0-9]+)+?)$/gnu:glibc:\1/'";
 glibc;;LGPL-2.1-or-later;"GNU\ C\ Library\ development\ release\ version\ [0-9](\.[0-9]+)+?$";"sed -r 's/GNU\ C\ Library\ development\ release\ version\ ([0-9](\.[0-9]+)+?)$/gnu:glibc:\1/'";
-glibc;;LGPL-2.1-or-later;"GNU\ C\ Library\ \(.*\)\ stable\ release\ version\ [0-9](\.[0-9]+)+?(\.)?$";"sed -r 's/GNU\ C\ Library\ \(.*\)\ stable\ release\ version\ ([0-9](\.[0-9]+)+?)$/gnu:glibc:\1/'";
+glibc;;LGPL-2.1-or-later;"GNU\ C\ Library\ \(.*\)\ stable\ release\ version\ [0-9](\.[0-9]+)+?(\.)?$";"sed -r 's/GNU\ C\ Library\ \(.*\)\ stable\ release\ version\ ([0-9](\.[0-9]+)+?)(\.)?$/gnu:glibc:\1/'";
 gnu_cpio;;GPL-3.0-only;"\(GNU\ cpio\)\ [0-9](\.[0-9]+)+?$";"sed -r 's/\(GNU\ cpio\)\ ([0-9](\.[0-9]+)+?)$/gnu:cpio:\1/'";
 gnu_findutils;;GPL-3.0-only;"\(GNU\ findutils\)\ [0-9](\.[0-9]+)+?$";"sed -r 's/\(GNU\ findutils\)\ ([0-9](\.[0-9]+)+?)$/gnu:findutils:\1/'";
 gnu_findutils;;GPL-3.0-only;"\(GNU\ findutils\)\ [0-9](\.[0-9]+)+?-[a-z]+$";"sed -r 's/\(GNU\ findutils\)\ ([0-9](\.[0-9]+)+?-[a-z]+)$/gnu:findutils:\1/'";

--- a/config/bin_version_strings_quick.cfg
+++ b/config/bin_version_strings_quick.cfg
@@ -173,10 +173,10 @@ ip6tables;;GPL-2.0-only;"ip6tables\ v[1-9](\.[0-9]+)+?$";"sed -r 's/ip6tables\ v
 ipunz;;commercial;"^ipunz V[0-9]\.[0-9]$";"sed -r 's/ipunz\ V([0-9](\.[0-9]+)+?)$/ipcomm:ipunz:\1/'";
 ipzip;;commercial;"^ipzip V[0-9]\.[0-9]$";"sed -r 's/ipzip\ V([0-9](\.[0-9]+)+?)$/ipcomm:ipzip:\1/'";
 iputils;;unknown;"iputils-s{,3}[0-9]+";"sed -r 's/iputils-s{,3}([0-9]+)$/iputils:\1/'";
-isc-dhclient;;ISC;"Internet\ Systems\ Consortium\ DHCP\ Client\ [0-9](\.[0-9]+)+?([a-z][0-9])?$";"sed -r 's/Internet\ Systems\ Consortium\ DHCP\ Client\ ([0-9](\.[0-9]+)+?([a-z][0-9])?)$/isc:dhcp_client:\1/'";
-isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?)$/isc:dhcp_client:\1/'";
-isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?-([ABPabp]|rc|RC)[0-3]$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?(-([ABPabp]|rc|RC)[0-3])?)$/isc:dhcp_client:\1/'";
-isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?-ESV-R[0-9]$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?(-ESV-R[0-9])?)$/isc:dhcp_client:\1/'";
+isc-dhclient;;ISC;"Internet\ Systems\ Consortium\ DHCP\ Client\ [0-9](\.[0-9]+)+?([a-z][0-9])?$";"sed -r 's/Internet\ Systems\ Consortium\ DHCP\ Client\ ([0-9](\.[0-9]+)+?([a-z][0-9])?)$/isc:dhcp:\1/'";
+isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?)$/isc:dhcp:\1/'";
+isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?-([ABPabp]|rc|RC)[0-3]$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?(-([ABPabp]|rc|RC)[0-3])?)$/isc:dhcp:\1/'";
+isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?-ESV-R[0-9]$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?(-ESV-R[0-9])?)$/isc:dhcp:\1/'";
 iwconfig;;unknown;"iwconfig\ \ Version\ [0-9]+$";"sed -r 's/iwconfig(\ )+Version\ ([0-9]+)$/wireless_tools:\2/'";
 iwconfig;;unknown;"iwconfig\ \ Wireless-Tools\ version\ [0-9]+";"sed -r 's/iwconfig(\ )+Wireless-Tools\ version\ ([0-9]+).*/wireless_tools:\2/'";
 iwevent;;unknown;"iwevent\ \ \ Wireless-Tools\ version\ [0-9]+";"sed -r 's/iwevent(\ )+Wireless-Tools\ version\ ([0-9]+).*/wireless_tools:\2/'";

--- a/config/bin_version_strings_quick.cfg
+++ b/config/bin_version_strings_quick.cfg
@@ -113,7 +113,7 @@ glibc;;LGPL-2.1-or-later;"GNU\ C\ Library\ \(GLIBC\)\ stable\ release\ version\ 
 glibc;;LGPL-2.1-or-later;"GNU\ C\ Library\ stable\ release\ version\ [0-9](\.[0-9]+)+?,\ ";"sed -r 's/GNU\ C\ Library\ stable\ release\ version\ ([0-9](\.[0-9]+)+?),\ .*/gnu:glibc:\1/'";
 glibc;;LGPL-2.1-or-later;"ldconfig\ \(GNU\ libc\)\ [0-9](\.[0-9]+)+?$";"sed -r 's/ldconfig\ \(GNU\ libc\)\ ([0-9](\.[0-9]+)+?)$/gnu:glibc:\1/'";
 glibc;;LGPL-2.1-or-later;"GNU\ C\ Library\ development\ release\ version\ [0-9](\.[0-9]+)+?$";"sed -r 's/GNU\ C\ Library\ development\ release\ version\ ([0-9](\.[0-9]+)+?)$/gnu:glibc:\1/'";
-glibc;;LGPL-2.1-or-later;"GNU\ C\ Library\ \(.*\)\ stable\ release\ version\ [0-9](\.[0-9]+)+?(\.)?$";"sed -r 's/GNU\ C\ Library\ \(.*\)\ stable\ release\ version\ ([0-9](\.[0-9]+)+?)(\.)?$/gnu:glibc:\1/'";
+glibc;;LGPL-2.1-or-later;"GNU\ C\ Library\ \(.*\)\ stable\ release\ version\ [0-9](\.[0-9]+)+?(\.)?$";"sed -r 's/GNU\ C\ Library\ \(.*\)\ stable\ release\ version\ ([0-9](\.[0-9]+)+?)$/gnu:glibc:\1/'";
 gnu_cpio;;GPL-3.0-only;"\(GNU\ cpio\)\ [0-9](\.[0-9]+)+?$";"sed -r 's/\(GNU\ cpio\)\ ([0-9](\.[0-9]+)+?)$/gnu:cpio:\1/'";
 gnu_findutils;;GPL-3.0-only;"\(GNU\ findutils\)\ [0-9](\.[0-9]+)+?$";"sed -r 's/\(GNU\ findutils\)\ ([0-9](\.[0-9]+)+?)$/gnu:findutils:\1/'";
 gnu_findutils;;GPL-3.0-only;"\(GNU\ findutils\)\ [0-9](\.[0-9]+)+?-[a-z]+$";"sed -r 's/\(GNU\ findutils\)\ ([0-9](\.[0-9]+)+?-[a-z]+)$/gnu:findutils:\1/'";
@@ -173,10 +173,10 @@ ip6tables;;GPL-2.0-only;"ip6tables\ v[1-9](\.[0-9]+)+?$";"sed -r 's/ip6tables\ v
 ipunz;;commercial;"^ipunz V[0-9]\.[0-9]$";"sed -r 's/ipunz\ V([0-9](\.[0-9]+)+?)$/ipcomm:ipunz:\1/'";
 ipzip;;commercial;"^ipzip V[0-9]\.[0-9]$";"sed -r 's/ipzip\ V([0-9](\.[0-9]+)+?)$/ipcomm:ipzip:\1/'";
 iputils;;unknown;"iputils-s{,3}[0-9]+";"sed -r 's/iputils-s{,3}([0-9]+)$/iputils:\1/'";
-isc-dhclient;;ISC;"Internet\ Systems\ Consortium\ DHCP\ Client\ [0-9](\.[0-9]+)+?([a-z][0-9])?$";"sed -r 's/Internet\ Systems\ Consortium\ DHCP\ Client\ ([0-9](\.[0-9]+)+?([a-z][0-9])?)$/isc:dhcp:\1/'";
-isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?)$/isc:dhcp:\1/'";
-isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?-([ABPabp]|rc|RC)[0-3]$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?(-([ABPabp]|rc|RC)[0-3])?)$/isc:dhcp:\1/'";
-isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?-ESV-R[0-9]$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?(-ESV-R[0-9])?)$/isc:dhcp:\1/'";
+isc-dhclient;;ISC;"Internet\ Systems\ Consortium\ DHCP\ Client\ [0-9](\.[0-9]+)+?([a-z][0-9])?$";"sed -r 's/Internet\ Systems\ Consortium\ DHCP\ Client\ ([0-9](\.[0-9]+)+?([a-z][0-9])?)$/isc:dhcp_client:\1/'";
+isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?)$/isc:dhcp_client:\1/'";
+isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?-([ABPabp]|rc|RC)[0-3]$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?(-([ABPabp]|rc|RC)[0-3])?)$/isc:dhcp_client:\1/'";
+isc-dhclient;;ISC;"isc-dhclient-[0-9](\.[0-9]+)+?-ESV-R[0-9]$";"sed -r 's/isc-dhclient-([0-9](\.[0-9]+)+?(-ESV-R[0-9])?)$/isc:dhcp_client:\1/'";
 iwconfig;;unknown;"iwconfig\ \ Version\ [0-9]+$";"sed -r 's/iwconfig(\ )+Version\ ([0-9]+)$/wireless_tools:\2/'";
 iwconfig;;unknown;"iwconfig\ \ Wireless-Tools\ version\ [0-9]+";"sed -r 's/iwconfig(\ )+Wireless-Tools\ version\ ([0-9]+).*/wireless_tools:\2/'";
 iwevent;;unknown;"iwevent\ \ \ Wireless-Tools\ version\ [0-9]+";"sed -r 's/iwevent(\ )+Wireless-Tools\ version\ ([0-9]+).*/wireless_tools:\2/'";


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixes version mismatches

* **What is the current behavior?** (You can also link to an open issue here)

`gnu:glibc` can be matched with a string that `sed` fails to replace with `gnu:glibc:version`. Later on, in F20, `glibc` is ignored because of a "bad version format" and CVEs are not fetched

ISC DHCP client binaries match `isc:dhcp_client` product name. No CVE are found, whatever the version, since the NVD database uses `isc:dhcp` for the client, not `isc:dhcp_client`

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

Proper product:version is returned and corresponding CVEs are reported

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No breaking change

* **Other information**:
