### PR TITLE
fix zlib (unzip) version string

### DIFF
--- a/config/bin_version_strings.cfg
+++ b/config/bin_version_strings.cfg
@@ -787,5 +787,5 @@ zipnote;;unknown;"ZipNote\ [0-9](\.[0-9]+)+?\ ";"sed -r 's/ZipNote\ ([0-9](\.[0-
 zipsplit;;bsd-style;"ZipSplit\ [0-9](\.[0-9]+)+?";"sed -r 's/ZipSplit\ ([0-9](\.[0-9]+)+?)/info-zip:zip:\1/'";
 zlib;;Zlib;"deflate\ [0-9](\.[0-9]+)+?\ Copyright.*Mark\ Adler";"sed -r 's/deflate\ ([0-9](\.[0-9]+)+?)\ .*/zlib:\1/'";
 zlib;;Zlib;"inflate\ [0-9](\.[0-9]+)+?\ Copyright.*Mark Adler";"sed -r 's/inflate\ ([0-9](\.[0-9]+)+?)\ .*/zlib:\1/'";
-zlib;;Zlib;"^\ unzip\ [0-9]\.([0-9]+)\ Copyright 1998-20[0-9][0-9] Gilles Vollant.*$";"sed -r 's/unzip\ ([0-9])\.([0-9])([0-9]*)\ Copyright 1998-20[0-9][0-9] Gilles Vollant.*/zlib:\1.\2.\3/'";
+zlib;;Zlib;"^\ unzip\ [0-9]\.([0-9]+)\ Copyright 1998-20[0-9][0-9] Gilles Vollant.*$";"sed -r 's/\ unzip\ ([0-9])\.([0-9])([0-9]*)\ Copyright 1998-20[0-9][0-9] Gilles Vollant.*/zlib:\1.\2.\3/'";
 log4j-core*.jar;zgrep;Apache-2.0;"Log4jReleaseVersion";"sed -r 's/Log4jReleaseVersion:\ ([0-9](\.[0-9]+)+?)/log4j:\1/'";


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)**

bug fix

* **What is the current behavior?** (You can also link to an open issue here)**

Des not search for CVEs for `zlib` if it is detected with the `unzip` version string, because the leading space in the matched string is kept in the `name:version` replacement string.

In `s09_firmware_base_version_check.txt`

```
[+] Version information found  unzip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll in binary logs/firmware/patool_extraction/disk3/opt/navi/EBNavi/libBusinessLogic.so (-rwxrwxr-x root root) (license: Zlib) (static).
[+] Version information found  unzip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll in binary logs/firmware/patool_extraction/disk3/opt/navi/asia_navi/apnnavc (-rwxrwxr-x root root) (license: Zlib) (static).
```

In `f20_vul_aggregator.txt`

```
[[0;31m-[0m] WARNING: Broken version identifier found: [0;33m zlib:1.0.1[0m
```

Then F20 does not proceed any further.


* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

Now with the extra leading space removed, it correctly identifies `zlib` and finds CVEs:

```
[*] Vulnerability details for zlib / version 1.0.1 / source STAT:

	BIN NAME            :   BIN VERS    :   CVE ID            :  CVSS VALUE : EPSS :   SOURCE         :   EXPLOIT
	zlib                :   1.0.1       :  	CVE-2018-25032    :   7.5       :  NA  :   STAT           :   No exploit available
	zlib                :   1.0.1       :  	CVE-2002-0059     :   9.8       :  NA  :   STAT           :   No exploit available
	zlib                :   1.0.1       :  	CVE-2022-37434    :   9.8       :  NA  :   STAT           :   No exploit available
	zlib                :   1.0.1       :  	CVE-2023-6992     :   5.5       :  NA  :   STAT           :   No exploit available
	zlib                :   1.0.1       :  	CVE-2023-45853    :   9.8       :  NA  :   STAT           :   No exploit available

[+] Found 5 CVEs and 0 exploits (including POC's) in zlib with version 1.0.1 (source STAT).
```




* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)**

No

* **Other information**:
