### PR TITLE
L10 init recovery test mode

### DIFF
--- a/modules/L10_system_emulation.sh
+++ b/modules/L10_system_emulation.sh
@@ -838,7 +838,9 @@ main_emulation() {
 
       for lIPS_INT_VLAN_CFG in "${IPS_INT_VLAN[@]}"; do
         emulation_with_config "${lIPS_INT_VLAN_CFG}"
-        if [[ "${TCP}" != "ok" ]] && [[ "${PORTS_1st:-0}" -gt 0 ]]; then
+
+        if [[ "${TCP}" != "ok" ]]; then
+          print_output "[*] We are in the emergency init switch mode now"
           # just in case we have no running TCP service detected we try the other init mechanism (rdinit vs init)
           # this is only done if we have already switched inits and our first detection run has also network services detected
           switch_inits "${KINIT}"

--- a/modules/L10_system_emulation/inferService.sh
+++ b/modules/L10_system_emulation/inferService.sh
@@ -31,7 +31,8 @@ if [ -e /etc/manual.starter ]; then
 fi
 
 if [ -d /etc/init.d/ ]; then
-  for SERVICE in $("${BUSYBOX}" find /etc/init.d/ -name "*httpd*" -o -name "ftpd" -o -name "miniupnpd" -o -name "*apache*"); do
+  for SERVICE in $("${BUSYBOX}" find /etc/init.d/ -type f -name "*httpd*" -o -type f -name "ftpd" -o -type f -name "miniupnpd" \
+    -o -type f -name "*apache*" -o -type f -name "*init*" -o -type f -name "*service*"); do
     if [ -e "${SERVICE}" ]; then
       if ! "${BUSYBOX}" grep -q "${SERVICE}" /firmadyne/service 2>/dev/null; then
         "${BUSYBOX}" echo -e "[*] Writing EMBA service for ${ORANGE}${SERVICE} service${NC}"
@@ -79,11 +80,11 @@ fi
 # twonkystarter: F9K1119_WW_1.00.01.bin
 
 for BINARY in $("${BUSYBOX}" find / -name "lighttpd" -type f -o -name "upnp" -type f -o -name "upnpd" -type f \
-  -o -name "telnetd" -type f -o -name "mini_httpd" -type f -o -name "miniupnpd" -type f -o -name "mini_upnpd" -type f \
+  -o -name "*telnetd" -type f -o -name "mini_httpd" -type f -o -name "miniupnpd" -type f -o -name "mini_upnpd" -type f \
   -o -name "twonkystarter" -type f -o -name "httpd" -type f -o -name "goahead" -type f -o -name "alphapd" -type f \
   -o -name "uhttpd" -type f -o -name "miniigd" -type f -o -name "ISS.exe" -type f -o -name "ubusd" -type f \
   -o -name "streamd" -type f -o -name "wscd" -type f -o -name "ftpd" -type f -o -name "11N_UDPserver" -type f \
-  -o -name "nvram_daemon" -type f); do
+  -o -name "pppoe-server" -type f -o -name "pppd" -type f -o -name "nvram_daemon" -type f); do
 
   if [ -x "${BINARY}" ]; then
     SERVICE_NAME=$("${BUSYBOX}" basename "${BINARY}")


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

if the identified init config failes we do not test the other one as backup

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

now we also test the other one

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
