### PR TITLE
exit on pre-checking selection

### DIFF
--- a/emba
+++ b/emba
@@ -189,6 +189,15 @@ run_modules()
       SELECT_MODULES+=("S24")
     fi
 
+    # manual selection of pre-checking modules not supported. EMBA is doint this for you!
+    if [[ "${SELECT_MODULES[*]}" =~ [pP][0-9] ]]; then
+      print_ln "no_log"
+      print_output "[!] ERROR: Manual pre-checking module selection not supported" "no_log"
+      print_output "[!] Hint: Remove -m p[0-9]+ parameter" "no_log"
+      print_ln "no_log"
+      exit 1
+    fi
+
     for SELECT_NUM in "${SELECT_MODULES[@]}" ; do
       local MOD_FIN=0
       if [[ "${SELECT_NUM}" =~ ^["${MODULE_GROUP,,}","${MODULE_GROUP^^}"]{1}[0-9]+ ]]; then

--- a/emba
+++ b/emba
@@ -189,7 +189,7 @@ run_modules()
       SELECT_MODULES+=("S24")
     fi
 
-    # manual selection of pre-checking modules not supported. EMBA is doint this for you!
+    # manual selection of pre-checking modules not supported. EMBA is doing this for you!
     if [[ "${SELECT_MODULES[*]}" =~ [pP][0-9] ]]; then
       print_ln "no_log"
       print_output "[!] ERROR: Manual pre-checking module selection not supported" "no_log"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

EMBA does not support manual pre-checker selection. If a user is trying to select pre-checking modules via -m parameter EMBA behaves weird. (see #1373 )

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

warn and exit - closes #1373

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
