### PR TITLE
Fix empty results from S09 because of "grep: Argument list too long"

### DIFF
--- a/modules/S09_firmware_base_version_check.sh
+++ b/modules/S09_firmware_base_version_check.sh
@@ -744,7 +744,7 @@ bin_string_checker() {
       lVERSION_IDENTIFIER="${lVERSION_IDENTIFIER%\"}"
     fi
     # print_output "[*] Testing ${lVERSION_IDENTIFIER} from ${lVERSION_IDENTIFIERS_ARR[*]}" "no_log"
-    mapfile -t lMD5_SUM_MATCHES_ARR < <(grep -a -o -E -l "${lVERSION_IDENTIFIER}" "${LOG_PATH_MODULE}"/strings_bins/strings_* | rev | cut -d '/' -f 1 | rev | cut -d '_' -f2 | sort -u || true)
+    mapfile -t lMD5_SUM_MATCHES_ARR < <(grep -a -o -E -l -r "${lVERSION_IDENTIFIER}" "${LOG_PATH_MODULE}"/strings_bins | rev | cut -d '/' -f 1 | rev | cut -d '_' -f2 | sort -u || true)
     FILE_ARR=()
     for lMD5_SUM_MATCHED in "${lMD5_SUM_MATCHES_ARR[@]}"; do
       lMACHTED_FNAME=$(grep ";${lMD5_SUM_MATCHED};" "${P99_CSV_LOG}" | cut -d ';' -f1 || true)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

On a firmware that generates a sizable number of files (e.g. 13,000) under `s09_firmware_base_version_check/strings_bin`, S09 module fails to grep data from them and does not return any result overall.

Cause: the `grep` command (in the modified line in this PR) has its file pattern extended on the command line with all matching files. This exceeds the system maximum command-line length (2MB on my system, don't know how standard that is). The command does not return anything to `stdout`, as if no string matched `lVERSION_IDENTIFIER`.

Error was found by logging grep result, including `stderr`, from that location:

```sh
    lGREP_RESULT=$(grep -a -o -E -l "${lVERSION_IDENTIFIER}" "${LOG_PATH_MODULE}"/strings_bins/strings_* 2>&1)
    print_output "[*] DBG ${lGREP_RESULT}" 
```
This logs `DBG /usr/bin/grep: Argument list too long` for every `lVERSION_IDENTIFIER`


* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

Given that this folder only contains `strings_*` files, we can call grep on the whole folder with the `-r` option. Results are now returned as expected from this command.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:

None
