### PR TITLE
Effective (and fast) S09 threading

### DIFF
--- a/modules/S09_firmware_base_version_check.sh
+++ b/modules/S09_firmware_base_version_check.sh
@@ -154,8 +154,13 @@ S09_firmware_base_version_check() {
     local lTMP_PID="$!"
     store_kill_pids "${lTMP_PID}"
     WAIT_PIDS_S09_1+=( "${lTMP_PID}" )
-    max_pids_protection $(( "${MAX_MOD_THREADS}"*3 )) "${WAIT_PIDS_S09_1[@]}"
-  done
+    if [[ "${#WAIT_PIDS_S09_1[@]}" -gt "${MAX_MOD_THREADS}" ]]; then
+      recover_wait_pids WAIT_PIDS_S09_1
+      if [[ "${#WAIT_PIDS_S09_1[@]}" -gt "${MAX_MOD_THREADS}" ]]; then
+        max_pids_protection $(( "${MAX_MOD_THREADS}"*3 )) "${WAIT_PIDS_S09_1[@]}"
+      fi
+    fi
+done
 
   print_output "[*] Waiting for strings generator" "no_log"
   wait_for_pid "${WAIT_PIDS_S09_1[@]}"
@@ -508,7 +513,7 @@ S09_firmware_base_version_check() {
 
     if [[ "${THREADED}" -eq 1 ]]; then
       if [[ "${#WAIT_PIDS_S09[@]}" -gt "${MAX_MOD_THREADS}" ]]; then
-        recover_wait_pids "${WAIT_PIDS_S09[@]}"
+        recover_wait_pids WAIT_PIDS_S09
         if [[ "${#WAIT_PIDS_S09[@]}" -gt "${MAX_MOD_THREADS}" ]]; then
           max_pids_protection $(( "${MAX_MOD_THREADS}"*2 )) "${WAIT_PIDS_S09[@]}"
         fi
@@ -999,10 +1004,11 @@ bin_string_checker() {
 }
 
 recover_wait_pids() {
+  local -n lrWAIT_PIDS_ARR=$1
   local lTEMP_PIDS_ARR=()
   local lPID=""
   # check for really running PIDs and re-create the array
-  for lPID in "${WAIT_PIDS_S09[@]}"; do
+  for lPID in "${lrWAIT_PIDS_ARR[@]}"; do
     # print_output "[*] max pid protection: ${#WAIT_PIDS[@]}"
     if [[ -e /proc/"${lPID}" ]]; then
       lTEMP_PIDS_ARR+=( "${lPID}" )
@@ -1011,7 +1017,7 @@ recover_wait_pids() {
   # print_output "[!] S09 - really running pids: ${#lTEMP_PIDS_ARR[@]}"
 
   # recreate the array with the current running PIDS
-  WAIT_PIDS_S09=()
-  WAIT_PIDS_S09=("${lTEMP_PIDS_ARR[@]}")
+  lrWAIT_PIDS_ARR=()
+  lrWAIT_PIDS_ARR=("${lTEMP_PIDS_ARR[@]}")
 }
 

--- a/modules/S09_firmware_base_version_check.sh
+++ b/modules/S09_firmware_base_version_check.sh
@@ -1004,7 +1004,7 @@ bin_string_checker() {
 }
 
 recover_wait_pids() {
-  local -n lrWAIT_PIDS_ARR=$1
+  local -n lrWAIT_PIDS_ARR=${1:-}
   local lTEMP_PIDS_ARR=()
   local lPID=""
   # check for really running PIDs and re-create the array


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

"Improvement" or "bug fix", depending how we see it.


* **What is the current behavior?** (You can also link to an open issue here)

With `THREADED=1`, generating `strings_bins` in S09 is very slow, and get slower and slower as the number of generated files increases (gets slower than single-thread at some point)

Cause: one process is spawned per file to generate under `strings_bins`, and all their PIDs are kept in a list and not removed until all strings_bins are generated. Once the PIDs lists is longer than `${MAX_MOD_THREADS}*3`, the `max_pids_protection` kicks in to make sure there aren't too many processes at once. Problem is, as the PIDs list gets longer, `max_pids_protection` takes longer to execute than the last spawned process to extract strings (mostly because of checking so many dead PIDs I guess). Since a new process is not spawned until `max_pids_protection` returns, what we have is a "main process" doing nothing but checking dead PIDs and short "job processes" running only once in a while.

There is also a potential issue (not observed for sure yet) with PID recycling over time. See **other information** below.


* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

String generation is now "really" multi-threaded and much faster, especially on large firmwares. To do so, the PID list is cleaned up from dead PID at every `MAX_MOD_THREADS` spawned process (in tests, most often all processes were dead and cleaned up, and sometimes there was 1 still running). 

To do so, existing logic in S09 (in the second part of S09) was adapted and reused. 

Here's an anecdotical benchmark performed on a firmware that I can't share. 
- Ubuntu VM with 32 cores and 96 GB RAM
- EMBA running in a Docker container
- S09 generates about 13,000 files under `strings_bins`
- variables at S09 entry, if that matters:
   - THREADED: 1 
   - QEMULATION: 1
   - SELECTED_MODULES: ("S06" "S08" "S09" "S24" "S25" "S26" "S115" "S116" "S118")
   - SBOM_UNTRACKED_FILES: 1
   - FIRMWARE: 1
   - RTOS: 0
- S09 happened to be running at the same time as S25 and S115, but even though this might blur timings somewhat, the improvement is clear. 

Generating strings took 4 **hours** (almost exactly) before fix, and under 6 **minutes** after the fix. This is only for the string generation part. The remainder of S09 took about 20 minutes to execute in both cases (did not expect any change).

Also, looking at file access times in `strings_bins` folder, I can roughly compute the average throughput (how much files created per seconds) at various points of S09 execution:
- After fix: about 36 files/sec from start to end
- Before fix:
   - Around the 50th: 38
   - Around the 500th: 15
   - Around the 2,500th: 2.9
   - Around the 5,000th: 1.3
   - Around the 10,000th: 0.52
   - At the end (13,000 files): 0.34 (more than 100x slower than at the beginning)

Of course, extracted strings in `strings_bins` were the same before and after the fix. 


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.


* **Other information**:

Cleaning up the list of running PIDs in S09 not only speeds up things, but helps to prevent an issue with recycled PIDs.

When S09, S25 and S115 are running at once, and even when S09 is completed, I noticed on my system (and the above test firmware) that there is about 500,000 processes created per hour. At this rate, PIDs are recycled about every 8 hours (`pid_max` in the docker container on my system is 4 million) . After the fix, S09 doesn't run for very long anymore, but it used to before the fix, and others modules such as S25 and S115 (and others that come after) can still run for a very long time.

Keeping lists of spawned (and dead) PIDs for several hours is thus getting in the "danger zone" of monitoring (or even killing) unrelated processes. I haven't observed this yet, but on a very large firmware this could happen. As such, there might be other instances, in other modules, where it might be safer to tidy up PIDs list as it's now done in S09.

