### PR TITLE
S09 unique bins

### DIFF
--- a/modules/S09_firmware_base_version_check.sh
+++ b/modules/S09_firmware_base_version_check.sh
@@ -728,7 +728,7 @@ bin_string_checker() {
   local lMD5_SUM=""
   local lMD5_SUM_MATCHES_ARR=()
   local lMD5_SUM_MATCHED=""
-  local lMACHTED_FNAME=""
+  local lMATCHED_FNAME=""
   local lBIN_DEPS_ARR=()
   local lBIN_DEPENDENCY=""
 
@@ -748,9 +748,9 @@ bin_string_checker() {
     mapfile -t lMD5_SUM_MATCHES_ARR < <(grep -a -o -E -l -r "${lVERSION_IDENTIFIER}" "${LOG_PATH_MODULE}"/strings_bins | rev | cut -d '/' -f 1 | rev | cut -d '_' -f2 | sort -u || true)
     FILE_ARR=()
     for lMD5_SUM_MATCHED in "${lMD5_SUM_MATCHES_ARR[@]}"; do
-      lMACHTED_FNAME=$(grep ";${lMD5_SUM_MATCHED};" "${P99_CSV_LOG}" | cut -d ';' -f1 | head -1 || true)
-      FILE_ARR+=("${lMACHTED_FNAME}")
-      # print_output "[*] Matched ${lMACHTED_FNAME}" "no_log"
+      lMATCHED_FNAME=$(grep ";${lMD5_SUM_MATCHED};" "${P99_CSV_LOG}" | cut -d ';' -f1 | head -1 || true)
+      FILE_ARR+=("${lMATCHED_FNAME}")
+      # print_output "[*] Matched ${lMATCHED_FNAME}" "no_log"
     done
 
     if [[ "${#FILE_ARR[@]}" -eq 0 ]]; then

--- a/modules/S09_firmware_base_version_check.sh
+++ b/modules/S09_firmware_base_version_check.sh
@@ -748,7 +748,7 @@ bin_string_checker() {
     mapfile -t lMD5_SUM_MATCHES_ARR < <(grep -a -o -E -l -r "${lVERSION_IDENTIFIER}" "${LOG_PATH_MODULE}"/strings_bins | rev | cut -d '/' -f 1 | rev | cut -d '_' -f2 | sort -u || true)
     FILE_ARR=()
     for lMD5_SUM_MATCHED in "${lMD5_SUM_MATCHES_ARR[@]}"; do
-      lMACHTED_FNAME=$(grep ";${lMD5_SUM_MATCHED};" "${P99_CSV_LOG}" | cut -d ';' -f1 || true)
+      lMACHTED_FNAME=$(grep ";${lMD5_SUM_MATCHED};" "${P99_CSV_LOG}" | cut -d ';' -f1 | head -1 || true)
       FILE_ARR+=("${lMACHTED_FNAME}")
       # print_output "[*] Matched ${lMACHTED_FNAME}" "no_log"
     done


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

see https://github.com/e-m-b-a/emba/issues/1464

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

we only use one of the bins with the same MD5 sums. This does not really address the reported the race condition but it fixes the outcome in S09. In most of the other areas where we rely on P99_CSV we already did a `head -1`

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:

As we did not fix the source of this bug we leave the original bug report open.
