### PR TITLE
fix results from race condition in MD5 list generation

### DIFF
--- a/helpers/helpers_emba_helpers.sh
+++ b/helpers/helpers_emba_helpers.sh
@@ -94,7 +94,7 @@ max_pids_protection() {
     if [[ -f "${LOG_DIR}"/"${MAIN_LOG_FILE}" ]] && [[ $(grep -i -c S115_ "${LOG_DIR}"/"${MAIN_LOG_FILE}" || true) -eq 1 && -n "${QRUNTIME}" ]]; then
       killall -9 --quiet --older-than "${QRUNTIME}" -r .*qemu.*sta.* || true
     fi
-    
+
     filter_out_dead_pids lWAIT_PIDS_ARR
 
     print_dot

--- a/helpers/helpers_emba_helpers.sh
+++ b/helpers/helpers_emba_helpers.sh
@@ -58,6 +58,27 @@ wait_for_pid() {
   done
 }
 
+
+filter_out_dead_pids() {
+  local -n lrPIDS_ARR=${1:-}
+  local lTEMP_PIDS_ARR=()
+  local lPID=""
+
+  # print_output "[*] filter out dead pids from: ${#lrPIDS_ARR[@]}"
+  for lPID in "${lrPIDS_ARR[@]}"; do
+    if [[ -e /proc/"${lPID}" ]]; then
+      if ! grep -q "State:.*zombie.*" "/proc/${lPID}/status" 2>/dev/null; then
+        lTEMP_PIDS_ARR+=( "${lPID}" )
+      fi
+    fi
+  done
+  # print_output "[!] really running pids: ${#lTEMP_PIDS_ARR[@]}"
+
+  lrPIDS_ARR=()
+  lrPIDS_ARR=("${lTEMP_PIDS_ARR[@]}")
+}
+
+
 max_pids_protection() {
   if [[ -n "${1:-}" ]]; then
     local lMAX_PIDS_="${1:-}"
@@ -69,26 +90,13 @@ max_pids_protection() {
   local lPID=""
 
   while [[ ${#lWAIT_PIDS_ARR[@]} -gt "${lMAX_PIDS_}" ]]; do
-    local lTEMP_PIDS_ARR=()
-    # check for really running PIDs and re-create the array
-    for lPID in "${lWAIT_PIDS_ARR[@]}"; do
-      # print_output "[*] max pid protection: ${#lWAIT_PIDS_ARR[@]}"
-      if [[ -e /proc/"${lPID}" ]]; then
-        if ! grep -q "State:.*zombie.*" "/proc/${lPID}/status" 2>/dev/null; then
-          lTEMP_PIDS_ARR+=( "${lPID}" )
-        fi
-      fi
-    done
     # if S115 is running we have to kill old qemu processes
     if [[ -f "${LOG_DIR}"/"${MAIN_LOG_FILE}" ]] && [[ $(grep -i -c S115_ "${LOG_DIR}"/"${MAIN_LOG_FILE}" || true) -eq 1 && -n "${QRUNTIME}" ]]; then
       killall -9 --quiet --older-than "${QRUNTIME}" -r .*qemu.*sta.* || true
     fi
+    
+    filter_out_dead_pids lWAIT_PIDS_ARR
 
-    # print_output "[!] really running pids: ${#lTEMP_PIDS_ARR[@]}"
-
-    # recreate the arry with the current running PIDS
-    lWAIT_PIDS_ARR=()
-    lWAIT_PIDS_ARR=("${lTEMP_PIDS_ARR[@]}")
     print_dot
   done
 }

--- a/helpers/helpers_emba_prepare.sh
+++ b/helpers/helpers_emba_prepare.sh
@@ -167,10 +167,16 @@ binary_architecture_threader() {
   lMD5SUM="$(md5sum "${lBINARY}" || print_output "[-] Checksum error for binary ${lBINARY}" "no_log")"
   lMD5SUM="${lMD5SUM/\ *}"
 
-  if grep -q "${lMD5SUM}" "${TMP_DIR}/p99_md5sum_done.tmp" 2>/dev/null; then
+  local lDONE_MD5_FILE="${TMP_DIR}/p99_md5sum_done.tmp"  
+  local lDONE_MD5_LOCK="${lDONE_MD5_FILE}.lock"
+  exec {lDONE_MD5_LOCK_FD}>"${lDONE_MD5_LOCK}" || { print_output "[-] Error accessing ${lDONE_MD5_LOCK}. Skipping ${lBINARY}"; return; }
+  flock -x "${lDONE_MD5_LOCK_FD}"
+  if grep -q "${lMD5SUM}" "${lDONE_MD5_FILE}" 2>/dev/null; then
+    exec {lDONE_MD5_LOCK_FD}>&-
     return
   fi
-  echo "${lMD5SUM}" >> "${TMP_DIR}/p99_md5sum_done.tmp"
+  echo "${lMD5SUM}" >> "${lDONE_MD5_FILE}"
+  exec {lDONE_MD5_LOCK_FD}>&-
 
   print_dot
 

--- a/helpers/helpers_emba_prepare.sh
+++ b/helpers/helpers_emba_prepare.sh
@@ -253,6 +253,13 @@ architecture_check() {
       local lTMP_PID="$!"
       store_kill_pids "${lTMP_PID}"
       lWAIT_PIDS_P99_ARR+=( "${lTMP_PID}" )
+
+      if [[ "${#lWAIT_PIDS_P99_ARR[@]}" -gt "${MAX_MOD_THREADS}" ]]; then
+        filter_out_dead_pids lWAIT_PIDS_P99_ARR
+        if [[ "${#lWAIT_PIDS_P99_ARR[@]}" -gt "${MAX_MOD_THREADS}" ]]; then
+          max_pids_protection $(( "${MAX_MOD_THREADS}"*2 )) "${lWAIT_PIDS_P99_ARR[@]}"
+        fi
+      fi
     done
     wait_for_pid "${lWAIT_PIDS_P99_ARR[@]}"
 

--- a/helpers/helpers_emba_prepare.sh
+++ b/helpers/helpers_emba_prepare.sh
@@ -167,7 +167,7 @@ binary_architecture_threader() {
   lMD5SUM="$(md5sum "${lBINARY}" || print_output "[-] Checksum error for binary ${lBINARY}" "no_log")"
   lMD5SUM="${lMD5SUM/\ *}"
 
-  local lDONE_MD5_FILE="${TMP_DIR}/p99_md5sum_done.tmp"  
+  local lDONE_MD5_FILE="${TMP_DIR}/p99_md5sum_done.tmp"
   local lDONE_MD5_LOCK="${lDONE_MD5_FILE}.lock"
   exec {lDONE_MD5_LOCK_FD}>"${lDONE_MD5_LOCK}" || { print_output "[-] Error accessing ${lDONE_MD5_LOCK}. Skipping ${lBINARY}"; return; }
   flock -x "${lDONE_MD5_LOCK_FD}"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixes issue #1464  

* **What is the current behavior?** (You can also link to an open issue here)

See issue #1464  

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

A critical section is implemented through `flock` and prevents the race condition. MD5 sums in `p99_md5sum_done.tmp` and `P99_CSV_LOG` are now unique.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

Before the fix, with test "firmware" in issue #1464 , duplicate MD5 would occur once every few runs. After the fix it does not seem to occur at all, but I don't know how to devise a test to demonstrate that a race condition can't occur at that point.