### PR TITLE
Update dep check to warn if the cve-db from docker container will be used

### DIFF
--- a/helpers/helpers_emba_dependency_check.sh
+++ b/helpers/helpers_emba_dependency_check.sh
@@ -416,7 +416,7 @@ dependency_check()
   # Some other nice features like restarting the mongod will not work without root privs.
   if [[ "${QEMULATION}" -eq 1 && "${EUID}" -ne 0 ]] || [[ "${USE_DOCKER}" -eq 1 && "${EUID}" -ne 0 ]] || [[ "${FULL_EMULATION}" -eq 1 && "${EUID}" -ne 0 ]]; then
     if [[ "${QEMULATION}" -eq 1 && "${USE_DOCKER}" -eq 0 ]] || [[ "${FULL_EMULATION}" -eq 1 && "${USE_DOCKER}" -eq 0 ]]; then
-      print_output "    user permission - emulation mode - \\c" "no_log"
+      print_output "    User permission - emulation mode - \\c" "no_log"
       echo -e "${RED}""not ok""${NC}"
       echo -e "${RED}""    With emulation enabled this script needs root privileges""${NC}"
       DEP_EXIT=1
@@ -460,7 +460,7 @@ dependency_check()
   fi
 
   # Check for ./config
-  print_output "    configuration directory - \\c" "no_log"
+  print_output "    Configuration directory - \\c" "no_log"
   if ! [[ -d "${CONFIG_DIR}" ]] ; then
     echo -e "${RED}""not ok""${NC}"
     echo -e "${RED}""    Missing configuration directory - check your installation""${NC}"
@@ -481,11 +481,20 @@ dependency_check()
     fi
   fi
 
-  if ! [[ -f "${CONFIG_DIR}"/gh_action ]]; then
-    check_dep_file "NVD CVE database" "${EXT_DIR}""/nvd-json-data-feeds/README.md"
-  fi
   # Python virtual environment in external directory
   check_dep_file "Python virtual environment" "${EXT_DIR}""/emba_venv/bin/activate"
+
+  if ! [[ -f "${CONFIG_DIR}"/gh_action ]]; then
+    check_dep_file "NVD CVE database in JSON format" "${EXT_DIR}""/nvd-json-data-feeds/README.md"
+  fi
+
+  print_output "    SQLite CVE database update in config directory - \\c" "no_log"
+  if [[ ! -f "${CONFIG_DIR}/cve-database.db" ]]; then
+    echo -e "${ORANGE}""not ok""${NC}"
+    echo -e "${ORANGE}""    Missing SQLite CVE database updates - Check update instructions""${NC}"
+  else
+    echo -e "${GREEN}""ok""${NC}"
+  fi
 
   if [[ "${IN_DOCKER}" -eq 0 ]]; then
     print_ln "no_log"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

The SQLite database from cve-bin-tool needs updates. These updates should be stored in config. If there are no update files the dep checker should warn.

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

dep checker warns now:

![image](https://github.com/user-attachments/assets/c38a06f7-0703-42c9-be75-d69bcf2096ba)


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
