### PR TITLE
find and fix unprintable characters

### DIFF
--- a/modules/P50_binwalk_extractor.sh
+++ b/modules/P50_binwalk_extractor.sh
@@ -60,10 +60,6 @@ P50_binwalk_extractor() {
     binwalker_matryoshka "${lFW_PATH_BINWALK}" "${OUTPUT_DIR_BINWALK}"
   fi
 
-<<<<<<< Updated upstream
-  if [[ "${SBOM_MINIMAL:-0}" -ne 1 ]]; then
-    linux_basic_identification_binwalk "${OUTPUT_DIR_BINWALK}"
-=======
   print_ln
   if [[ -d "${lOUTPUT_DIR_BINWALK}" ]]; then
     remove_uprintable_paths "${lOUTPUT_DIR_BINWALK}"
@@ -90,25 +86,6 @@ P50_binwalk_extractor() {
     print_output "[*] Additionally the Linux path counter is ${ORANGE}${lLINUX_PATH_COUNTER_BINWALK}${NC}."
     print_ln
     tree -sh "${lOUTPUT_DIR_BINWALK}" | tee -a "${LOG_FILE}"
->>>>>>> Stashed changes
-    print_ln
-    if [[ -d "${OUTPUT_DIR_BINWALK}" ]]; then
-      lFILES_EXT_BW=$(find "${OUTPUT_DIR_BINWALK}" -xdev -type f | wc -l )
-      lUNIQUE_FILES_BW=$(find "${OUTPUT_DIR_BINWALK}" "${EXCL_FIND[@]}" -xdev -type f -exec md5sum {} \; | sort -u -k1,1 | cut -d\  -f3 | wc -l )
-      lDIRS_EXT_BW=$(find "${OUTPUT_DIR_BINWALK}" -xdev -type d | wc -l )
-      # lBINS_BW=$(find "${OUTPUT_DIR_BINWALK}" "${EXCL_FIND[@]}" -xdev -type f -exec file {} \; | grep -c "ELF" || true)
-    fi
-
-    if [[ "${lBINS_BW}" -gt 0 ]] || [[ "${lFILES_EXT_BW}" -gt 0 ]]; then
-      sub_module_title "Firmware extraction details"
-      print_output "[*] ${ORANGE}Binwalk${NC} results:"
-      print_output "[*] Found ${ORANGE}${lFILES_EXT_BW}${NC} files (${ORANGE}${lUNIQUE_FILES_BW}${NC} unique files) and ${ORANGE}${lDIRS_EXT_BW}${NC} directories at all."
-      # print_output "[*] Found ${ORANGE}${lBINS_BW}${NC} binaries."
-      print_output "[*] Additionally the Linux path counter is ${ORANGE}${LINUX_PATH_COUNTER_BINWALK}${NC}."
-      print_ln
-      tree -sh "${OUTPUT_DIR_BINWALK}" | tee -a "${LOG_FILE}"
-      print_ln
-    fi
   fi
 
   detect_root_dir_helper "${OUTPUT_DIR_BINWALK}"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The new binwalk version generates sometimes unprintable characters in file paths which are sometimes a problem for some modules like L10:

```
Error detected - status code 1
Command:  echo -e "Command:  ${ORANGE}${BASH_COMMAND}${NC}"
Location:  ./modules/L10_system_emulation.sh, line 298
Stack Trace:
    [1] create_emulation_filesystem(): ./modules/L10_system_emulation.sh, line 298 -> create_emulation_filesystem $'/logs/firmware/binwalk_extracted/firmware.extracted/0/FW_WL_330N_1029.trx.extracted/0/\001\001.bin.extracted/CAD12/squashfs-root' mipsel
    [2] main_emulation(): ./modules/L10_system_emulation.sh, line 506 -> main_emulation $'/logs/firmware/binwalk_extracted/firmware.extracted/0/FW_WL_330N_1029.trx.extracted/0/\001\001.bin.extracted/CAD12/squashfs-root' mipsel
    [3] L10_system_emulation(): ./modules/L10_system_emulation.sh, line 152 -> L10_system_emulation
    [4] run_modules(): ./emba, line 250 -> run_modules L 0 0
    [5] main(): ./emba, line 945 -> main
    [6] main(): ./emba, line 1015 -> main
```

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

We check the extracted files for unprintable chars in paths and remove them.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
