### PR TITLE
P50 p55 emulation switch

### DIFF
--- a/helpers/fix_bins_lnk_emulation.sh
+++ b/helpers/fix_bins_lnk_emulation.sh
@@ -35,6 +35,10 @@ POSSIBLE_EXES_ARR=( "${POSSIBLE_ELFS[@]}" "${POSSIBLE_SH[@]}" )
 for POSSIBLE_EXE in "${POSSIBLE_EXES_ARR[@]}"; do
   [[ -x "${POSSIBLE_EXE}" ]] && continue
   if [[ -f "${POSSIBLE_EXE}" ]]; then
+    if [[ "${POSSIBLE_EXE}" == *"carved.elf" ]]; then
+      rm "${POSSIBLE_EXE}"
+      continue
+    fi
     echo "[*] Processing executable $(basename "${POSSIBLE_EXE}") - chmod privileges"
     chmod +x "${POSSIBLE_EXE}"
   fi

--- a/helpers/helpers_emba_prepare.sh
+++ b/helpers/helpers_emba_prepare.sh
@@ -576,6 +576,11 @@ detect_root_dir_helper() {
   local lINTERPRETER_ESCAPED=""
   local lCNT=0
 
+  if [[ ! -f "${P99_CSV_LOG}" ]]; then
+    print_output "[-] No ${P99_CSV_LOG} log file created ... no root directory detection possible"
+    return
+  fi
+
   if [[ "${SBOM_MINIMAL:-0}" -eq 0 ]]; then
     # xargs threading is much faster. Big testcase firmware 9mins vs. 3mins
     # mapfile -t lINTERPRETER_FULL_PATH_ARR < <(find "${lSEARCH_PATH}" -ignore_readdir_race -type f -print0|xargs -r -0 -P 16 -I % sh -c 'file -b % 2>/dev/null' | grep "ELF.*interpreter /" | sed "s/.*interpreter\ //" | sed "s/,\ .*$//" | sort -u || true)

--- a/installer/IL10_system_emulator.sh
+++ b/installer/IL10_system_emulator.sh
@@ -82,7 +82,7 @@ IL10_system_emulator() {
 
       apt-get install "${INSTALL_APP_LIST[@]}" -y --no-install-recommends
 
-      download_file "uml-utilities.deb" "http://ftp.de.debian.org/debian/pool/main/u/uml-utilities/uml-utilities_20070815.4-1+b1_amd64.deb" "external/uml-utilities.deb"
+      download_file "uml-utilities.deb" "http://ftp.de.debian.org/debian/pool/main/u/uml-utilities/uml-utilities_20070815.4-2_amd64.deb" "external/uml-utilities.deb"
       dpkg -i "external/uml-utilities.deb"
       rm -f "external/uml-utilities.deb"
 

--- a/modules/L10_system_emulation/inferService.sh
+++ b/modules/L10_system_emulation/inferService.sh
@@ -31,14 +31,14 @@ if [ -e /etc/manual.starter ]; then
 fi
 
 # we search for possible init startup directories and iterate them later for possible init scripts
-for INIT_DIR in $("${BUSYBOX}" find / -type d -name "*init.d*"); do
+for INIT_DIR in $("${BUSYBOX}" find / -type d -name "*init*\.d*"); do
   for SERVICE in $("${BUSYBOX}" find "${INIT_DIR}" -type f); do
     if "${BUSYBOX}" echo "${SERVICE}" | "${BUSYBOX}" grep -q "factory\|dhcp\|reset\|halt\|shutdown"; then
       # do not use entries like factory.init or init.factory and so on
       continue
     fi
     # currently we only use some services for startup
-    if "${BUSYBOX}" echo "${SERVICE}" | "${BUSYBOX}" grep -q "http\|ftp\|upnp\|apache\|service\|nvram\|telnet\|ssh\|snmp"; then
+    if "${BUSYBOX}" basename "${SERVICE}" | "${BUSYBOX}" grep -q "web\|http\|ftp\|upnp\|apache\|service\|nvram\|telnet\|ssh\|snmp\|rcS\|init"; then
       if [ -e "${SERVICE}" ]; then
         if ! "${BUSYBOX}" grep -q "${SERVICE}" /firmadyne/service 2>/dev/null; then
           "${BUSYBOX}" echo -e "[*] Writing EMBA service for ${ORANGE}${SERVICE} service${NC}"

--- a/modules/L10_system_emulation/inferService.sh
+++ b/modules/L10_system_emulation/inferService.sh
@@ -52,7 +52,7 @@ done
 # we search for possible rc startup directories and iterate them later for possible rc startup scripts
 for RC_DIR in $("${BUSYBOX}" find / -type d -name "*rc.d*"); do
   for SERVICE in $("${BUSYBOX}" find "${RC_DIR}" -type f); do
-    if "${BUSYBOX}" echo "${SERVICE}" | "${BUSYBOX}" grep -q "http\|ftp\|upnp\|apache\|service\|nvram\|telnet\|ssh\|snmp"; then
+    if "${BUSYBOX}" echo "${SERVICE}" | "${BUSYBOX}" grep -q "http\|ftp\|upnp\|apache\|service\|nvram\|telnet\|ssh\|snmp\|rcS\|init"; then
       if [ -e "${SERVICE}" ]; then
         if ! "${BUSYBOX}" grep -q "${SERVICE}" /firmadyne/service 2>/dev/null; then
           "${BUSYBOX}" echo -e "[*] Writing EMBA service for ${ORANGE}${SERVICE} service${NC}"
@@ -149,6 +149,8 @@ for BINARY in $("${BUSYBOX}" find / -name "*lighttpd" -type f -o -name "upnp" -t
         "${BUSYBOX}" echo -e -n "${BINARY}\n" >> /firmadyne/service
         "${BUSYBOX}" echo -e "[*] Writing EMBA starter for ${ORANGE}${BINARY} -L eth0 -W eth0${NC}"
         "${BUSYBOX}" echo -e -n "${BINARY} -L eth0 -W eth0\n" >> /firmadyne/service
+        "${BUSYBOX}" echo -e "[*] Writing EMBA starter for ${ORANGE}${BINARY} 0 EMBA EMBA EMBA EMBA EMBA EMBA 00:48:12:31:10:50 EMBA${NC}"
+        "${BUSYBOX}" echo -e -n "${BINARY} 0 EMBA EMBA EMBA EMBA EMBA EMBA 00:48:12:31:10:50 EMBA\n" >> /firmadyne/service
       fi
     elif [ "$("${BUSYBOX}" echo "${SERVICE_NAME}")" == "upnpd" ]; then
       if ! "${BUSYBOX}" grep -q "${BINARY}" /firmadyne/service 2>/dev/null; then

--- a/modules/L10_system_emulation/run_service.sh
+++ b/modules/L10_system_emulation/run_service.sh
@@ -101,7 +101,7 @@ if ("${EMBA_ETC}"); then
         "${BUSYBOX}" echo -e "${NC}[*] Starting ${ORANGE}${BINARY_NAME} - ${_BINARY}${NC} service ..."
         #BINARY variable could be something like: binary parameter parameter ...
         ${_BINARY} &
-        "${BUSYBOX}" ls -l ${_BINARY}
+        "${BUSYBOX}" ls -l "${_BINARY}"
       else
         "${BUSYBOX}" echo -e "${NC}[*] ${ORANGE}${BINARY_NAME}${NC} already started ..."
       fi

--- a/modules/L10_system_emulation/run_service.sh
+++ b/modules/L10_system_emulation/run_service.sh
@@ -101,6 +101,7 @@ if ("${EMBA_ETC}"); then
         "${BUSYBOX}" echo -e "${NC}[*] Starting ${ORANGE}${BINARY_NAME} - ${_BINARY}${NC} service ..."
         #BINARY variable could be something like: binary parameter parameter ...
         ${_BINARY} &
+        "${BUSYBOX}" ls -l ${_BINARY}
       else
         "${BUSYBOX}" echo -e "${NC}[*] ${ORANGE}${BINARY_NAME}${NC} already started ..."
       fi

--- a/modules/L10_system_emulation/run_service.sh
+++ b/modules/L10_system_emulation/run_service.sh
@@ -101,7 +101,9 @@ if ("${EMBA_ETC}"); then
         "${BUSYBOX}" echo -e "${NC}[*] Starting ${ORANGE}${BINARY_NAME} - ${_BINARY}${NC} service ..."
         #BINARY variable could be something like: binary parameter parameter ...
         ${_BINARY} &
-        "${BUSYBOX}" ls -l "${_BINARY}"
+        # strip only the real binary including path:
+        _BINARY_TMP=$("${BUSYBOX}" echo "${_BINARY}" | "${BUSYBOX}" cut -d ' ' -f1)
+        "${BUSYBOX}" ls -l "${_BINARY_TMP}"
       else
         "${BUSYBOX}" echo -e "${NC}[*] ${ORANGE}${BINARY_NAME}${NC} already started ..."
       fi

--- a/modules/P50_binwalk_extractor.sh
+++ b/modules/P50_binwalk_extractor.sh
@@ -36,6 +36,19 @@ P50_binwalk_extractor() {
     return
   fi
 
+  # We have seen multiple issues in system emulation while using binwalk
+  # * unprintable chars in paths -> remediation in place
+  # * lost symlinks in different firmware extractions -> Todo: Issue
+  # * lost permissions of executables -> remediation in place
+  # Currently we disable binwalk here and switch automatically to unblob is main extractor while
+  # system emulation runs. If unblob fails we are going to try an additional extraction round with
+  # binwalk.
+  if [[ "${FULL_EMULATION}" -eq 1 ]]; then
+    print_output "[-] Binwalk v3 has issues with symbolic links and is disabled for system emulation"
+    module_end_log "${FUNCNAME[0]}" 0
+    return
+  fi
+
   # we do not rely on any EMBA extraction mechanism -> we use the original firmware file
   local lFW_PATH_BINWALK="${FIRMWARE_PATH_BAK}"
 

--- a/modules/P55_unblob_extractor.sh
+++ b/modules/P55_unblob_extractor.sh
@@ -150,10 +150,10 @@ P55_unblob_extractor() {
       print_output "[*] Additionally the Linux path counter is ${ORANGE}${lLINUX_PATH_COUNTER_BINWALK}${NC}."
       print_ln
       tree -sh "${lOUTPUT_DIR_BINWALK}" | tee -a "${LOG_FILE}"
+      detect_root_dir_helper "${lOUTPUT_DIR_BINWALK}"
+      write_csv_log "FILES Binwalk recovery mode" "LINUX_PATH_COUNTER Binwalk"
+      write_csv_log "${#lFILES_BINWALK_ARR[@]}" "${lLINUX_PATH_COUNTER_BINWALK}"
     fi
-    detect_root_dir_helper "${lOUTPUT_DIR_BINWALK}"
-    write_csv_log "FILES Binwalk recovery mode" "LINUX_PATH_COUNTER Binwalk"
-    write_csv_log "${#lFILES_BINWALK_ARR[@]}" "${lLINUX_PATH_COUNTER_BINWALK}"
   fi
 
   write_csv_log "FILES Unblob" "LINUX_PATH_COUNTER Unblob"

--- a/modules/P55_unblob_extractor.sh
+++ b/modules/P55_unblob_extractor.sh
@@ -86,6 +86,7 @@ P55_unblob_extractor() {
   if [[ "${SBOM_MINIMAL:-0}" -ne 1 ]]; then
     print_ln
     if [[ -d "${lOUTPUT_DIR_UNBLOB}" ]]; then
+      remove_uprintable_paths "${lOUTPUT_DIR_UNBLOB}"
       mapfile -t lFILES_UNBLOB_ARR < <(find "${lOUTPUT_DIR_UNBLOB}" -type f ! -name "*.raw")
     fi
 
@@ -114,6 +115,46 @@ P55_unblob_extractor() {
   fi
 
   detect_root_dir_helper "${lOUTPUT_DIR_UNBLOB}"
+
+  # this is the 2nd run for full sytem emulation
+  # further comments on this mechanism in P50
+  # this will be removed in the future after binwalk is running as expected
+  if [[ "${FULL_EMULATION}" -eq 1 && "${RTOS}" -eq 1 ]]; then
+    local lOUTPUT_DIR_BINWALK=""
+    local lFILES_BINWALK_ARR=()
+
+    lOUTPUT_DIR_BINWALK="${lOUTPUT_DIR_UNBLOB//unblob/binwalk_recover}"
+    binwalker_matryoshka "${lFW_PATH_BINWALK}" "${lOUTPUT_DIR_BINWALK}"
+    if [[ -d "${lOUTPUT_DIR_BINWALK}" ]]; then
+      remove_uprintable_paths "${lOUTPUT_DIR_BINWALK}"
+      mapfile -t lFILES_BINWALK_ARR < <(find "${lOUTPUT_DIR_BINWALK}" -type f ! -name "*.raw")
+    fi
+
+    if [[ "${#lFILES_BINWALK_ARR[@]}" -gt 0 ]]; then
+      print_output "[*] Extracted ${ORANGE}${#lFILES_BINWALK_ARR[@]}${NC} files."
+      print_output "[*] Populating backend data for ${ORANGE}${#lFILES_BINWALK_ARR[@]}${NC} files ... could take some time" "no_log"
+
+      for lBINARY in "${lFILES_BINWALK_ARR[@]}" ; do
+        binary_architecture_threader "${lBINARY}" "${FUNCNAME[0]}" &
+        local lTMP_PID="$!"
+        store_kill_pids "${lTMP_PID}"
+        lWAIT_PIDS_P99_ARR+=( "${lTMP_PID}" )
+      done
+
+      lLINUX_PATH_COUNTER_BINWALK=$(linux_basic_identification "${lOUTPUT_DIR_BINWALK}" "${FUNCNAME[0]}")
+      wait_for_pid "${lWAIT_PIDS_P99_ARR[@]}"
+
+      sub_module_title "Firmware extraction details"
+      print_output "[*] ${ORANGE}Binwalk recovery${NC} results:"
+      print_output "[*] Found ${ORANGE}${#lFILES_BINWALK_ARR[@]}${NC} files."
+      print_output "[*] Additionally the Linux path counter is ${ORANGE}${lLINUX_PATH_COUNTER_BINWALK}${NC}."
+      print_ln
+      tree -sh "${lOUTPUT_DIR_BINWALK}" | tee -a "${LOG_FILE}"
+    fi
+    detect_root_dir_helper "${lOUTPUT_DIR_BINWALK}"
+    write_csv_log "FILES Binwalk recovery mode" "LINUX_PATH_COUNTER Binwalk"
+    write_csv_log "${#lFILES_BINWALK_ARR[@]}" "${lLINUX_PATH_COUNTER_BINWALK}"
+  fi
 
   write_csv_log "FILES Unblob" "LINUX_PATH_COUNTER Unblob"
   write_csv_log "${#lFILES_UNBLOB_ARR[@]}" "${lLINUX_PATH_COUNTER_UNBLOB}"

--- a/modules/P55_unblob_extractor.sh
+++ b/modules/P55_unblob_extractor.sh
@@ -124,7 +124,7 @@ P55_unblob_extractor() {
     local lFILES_BINWALK_ARR=()
 
     lOUTPUT_DIR_BINWALK="${lOUTPUT_DIR_UNBLOB//unblob/binwalk_recover}"
-    binwalker_matryoshka "${lFW_PATH_BINWALK}" "${lOUTPUT_DIR_BINWALK}"
+    binwalker_matryoshka "${lFW_PATH_UNBLOB}" "${lOUTPUT_DIR_BINWALK}"
     if [[ -d "${lOUTPUT_DIR_BINWALK}" ]]; then
       remove_uprintable_paths "${lOUTPUT_DIR_BINWALK}"
       mapfile -t lFILES_BINWALK_ARR < <(find "${lOUTPUT_DIR_BINWALK}" -type f ! -name "*.raw")

--- a/modules/P60_deep_extractor.sh
+++ b/modules/P60_deep_extractor.sh
@@ -118,6 +118,12 @@ deep_extractor() {
   sub_module_title "Deep extraction mode"
   local lFILES_AFTER_DEEP=0
   local lFILES_BEFORE_DEEP=0
+
+  if [[ ! -f "${P99_CSV_LOG}" ]]; then
+    print_output "[-] No ${P99_CSV_LOG} log file created ... no deep extraction possible"
+    return
+  fi
+
   lFILES_BEFORE_DEEP=$(wc -l "${P99_CSV_LOG}" | awk '{print $1}')
 
   # if we run into the deep extraction mode we always do at least one extraction round:

--- a/modules/S02_UEFI_FwHunt.sh
+++ b/modules/S02_UEFI_FwHunt.sh
@@ -37,7 +37,7 @@ S02_UEFI_FwHunt() {
     fwhunter "${FIRMWARE_PATH_BAK}"
     if [[ $(grep -c "FwHunt rule" "${LOG_PATH_MODULE}""/fwhunt_scan_"* | cut -d: -f2 | awk '{ SUM += $1} END { print SUM }' || true) -eq 0 ]]; then
       while read -r lFILE_DETAILS; do
-        lEXTRACTED_FILE="${lFILE_DETAILS/;*}"
+        lEXTRACTED_FILE=$(echo "${lFILE_DETAILS}" | cut -d ';' -f2)
         if [[ ${THREADED} -eq 1 ]]; then
           fwhunter "${lEXTRACTED_FILE}" &
           local lTMP_PID="$!"

--- a/modules/S24_kernel_bin_identifier.sh
+++ b/modules/S24_kernel_bin_identifier.sh
@@ -38,7 +38,7 @@ S24_kernel_bin_identifier()
 
   # for lFILE in "${ALL_FILES_ARR[@]}" ; do
   while read -r lFILE; do
-    lFILE="${lFILE/;*}"
+    lFILE=$(echo "${lFILE}" | cut -d ';' -f2)
     local lK_ELF="NA"
     local lKCONFIG_EXTRACTED="NA"
     local lK_VER_CLEAN="NA"

--- a/modules/S85_ssh_check.sh
+++ b/modules/S85_ssh_check.sh
@@ -167,6 +167,7 @@ check_squid() {
   local lSQUID_PATHS_ARR=()
 
   while read -r lSQUID_FILE; do
+    lSQUID_FILE="$(echo "${lSQUID_FILE}" | cut -d ';' -f2)"
     print_output "[+] Found possible squid executable: ""${ORANGE}$(print_path "${lSQUID_FILE/;*}")${NC}"
     ((SQUID_VUL_CNT+=1))
   done < <(grep "squid" "${P99_CSV_LOG}" | grep ";ELF" || true)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

We have seen multiple issues in using binwalk v3 for system emulation. The major issue is currently that on some firmware files binwalk loses symlinks. For system emulation this does not work and we have switched back to unblob first and binwalk as backup in such cases. We are going to open an issue to hopefully get it also addressed directly in binwalk.

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

For system emulation unblob is used as first extractor and binwalk as backup

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
