### PR TITLE
remove hardcoded linux kernel version

### DIFF
--- a/modules/L10_system_emulation.sh
+++ b/modules/L10_system_emulation.sh
@@ -2623,7 +2623,7 @@ create_emulation_archive() {
     sed -i 's/-serial\ file:.*\/l10_system_emulation\/qemu\.final\.serial\.log/-serial\ file:\.\/qemu\.serial\.log/g' "${lARCHIVE_PATH}"/run.sh
     # fix the path for the kernel which is currently something like ./Linux-Kernel/vmlinux.mipsel.4
     # and should be ./vmlinux.mipsel.4
-    local lL10_KERNEL_V_LONG_TMP="4.1.52"
+    local lL10_KERNEL_V_LONG_TMP="${L10_KERNEL_V_LONG}"
     if [[ "${lARCH_END}" == *"x86el"* ]] && [[ "${L10_KERNEL_V_LONG}" == "4.1.52" ]]; then
       # for x86el we currently have kernel issues
       lL10_KERNEL_V_LONG_TMP="4.1.17"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
it removes the hardcoded version of the linux kernel.


* **What is the current behavior?** (You can also link to an open issue here)
Hardcoded values.


* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**
The variable L10_KERNEL_V_LONG is used.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
