### PR TITLE
Improve sorting of L10 configs

### DIFF
--- a/modules/L10_system_emulation.sh
+++ b/modules/L10_system_emulation.sh
@@ -836,7 +836,7 @@ main_emulation() {
       local lNW_ENTRY_PRIO=0
       local lIPS_INT_VLAN_TMP=()
 
-      mapfile -t IPS_INT_VLAN < <(printf "%s\n" "${IPS_INT_VLAN[@]}" | sort -u -t ';' -k 1,1r -k 5,5)
+      mapfile -t IPS_INT_VLAN < <(printf "%s\n" "${IPS_INT_VLAN[@]}" | sort -u -t ';' -k 1,1r -k 5,5n)
       for lIPS_INT_VLAN_CFG in "${IPS_INT_VLAN[@]}"; do
         lNW_ENTRY_PRIO="${lIPS_INT_VLAN_CFG/\;*}"
         lIP_CFG=$(echo "${lIPS_INT_VLAN_CFG}" | cut -d\; -f2)

--- a/modules/L10_system_emulation.sh
+++ b/modules/L10_system_emulation.sh
@@ -836,8 +836,7 @@ main_emulation() {
       local lNW_ENTRY_PRIO=0
       local lIPS_INT_VLAN_TMP=()
 
-      # eval "IPS_INT_VLAN=($(for i in "${IPS_INT_VLAN[@]}" ; do echo "\"${i}\"" ; done | sort -u -r))"
-      mapfile -t IPS_INT_VLAN < <(printf "%s\n" "${IPS_INT_VLAN[@]}" | sort -u -r)
+      mapfile -t IPS_INT_VLAN < <(printf "%s\n" "${IPS_INT_VLAN[@]}" | sort -u -t ';' -k 1,1r -k 5,5)
       for lIPS_INT_VLAN_CFG in "${IPS_INT_VLAN[@]}"; do
         lNW_ENTRY_PRIO="${lIPS_INT_VLAN_CFG/\;*}"
         lIP_CFG=$(echo "${lIPS_INT_VLAN_CFG}" | cut -d\; -f2)

--- a/modules/S24_kernel_bin_identifier.sh
+++ b/modules/S24_kernel_bin_identifier.sh
@@ -26,13 +26,12 @@ S24_kernel_bin_identifier()
 
   local lNEG_LOG=0
   local lFILE_PATH=""
-  local lK_VER=""
   local lK_INITS_ARR=()
   local lK_INIT=""
   local lCFG_MD5=""
   export KCFG_MD5_ARR=()
 
-  write_csv_log "Kernel version orig" "Kernel version stripped" "file" "generated elf" "identified init" "config extracted" "kernel symbols" "architecture" "endianness"
+  # write_csv_log "Kernel version orig" "Kernel version stripped" "file" "generated elf" "identified init" "config extracted" "kernel symbols" "architecture" "endianness"
 
   local lWAIT_PIDS_S24_main=()
   # just in case s09 has not already created the strings output directory
@@ -226,10 +225,10 @@ binary_kernel_check_threader() {
               if [[ "${lCFG_CNT}" -lt 50 ]]; then
                 lKCONFIG_EXTRACTED="NA"
               fi
-              write_csv_log "${lK_VER}" "${lK_VER_CLEAN}" "${lFILE_PATH}" "${lBIN_FILE:-NA}" "${lK_INIT}" "${lKCONFIG_EXTRACTED}" "${lK_SYMBOLS}" "${lK_ARCH}" "${lK_ARCH_END}"
+              write_csv_log "${lFILE_PATH}" "${lK_VER_CLEAN}" "${lBIN_FILE:-NA}" "${lK_INIT}" "${lKCONFIG_EXTRACTED}" "${lK_SYMBOLS}" "${lK_ARCH}" "${lK_ARCH_END}"
             done
           else
-            write_csv_log "${lK_VER}" "${lK_VER_CLEAN}" "${lFILE_PATH}" "${lBIN_FILE:-NA}" "NA" "${lKCONFIG_EXTRACTED}" "${lK_SYMBOLS}" "${lK_ARCH}" "${lK_ARCH_END}"
+            write_csv_log "${lFILE_PATH}" "${lK_VER_CLEAN}" "${lBIN_FILE:-NA}" "NA" "${lKCONFIG_EXTRACTED}" "${lK_SYMBOLS}" "${lK_ARCH}" "${lK_ARCH_END}"
           fi
         done
       fi


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

Sorting of possible network configurations is not ideal

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

First, take the prio, 2nd criteria is now the vlan id

* **Other information**:

Note: Looks as S24 csv log is broken. Will address this later