### PR TITLE
Fix: release files cfg typo for SuSE

### DIFF
--- a/config/release_files.cfg
+++ b/config/release_files.cfg
@@ -4,7 +4,7 @@
 */os_release
 */os-release
 */release
-S*/uSE-release
+*/SuSE-release
 */UnitedLinux-release
 */annvix-release
 */arch-release


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Typo fix for SuSE-release in release_files.cfg

* **What is the current behavior?** (You can also link to an open issue here)

Unable to retrieve os information for SuSE

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

Able to retrieve os information for SuSE

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
