### PR TITLE
Add missing csv header fields to S12_binary_protection.sh

### DIFF
--- a/modules/S12_binary_protection.sh
+++ b/modules/S12_binary_protection.sh
@@ -33,7 +33,7 @@ S12_binary_protection()
     lCSV_LOG="${LOG_FILE_NAME/\.txt/\.csv}"
     lCSV_LOG="${CSV_DIR}""/""${lCSV_LOG}"
 
-    echo "RELRO;STACK CANARY;NX;PIE;RPATH;RUNPATH;Symbols;FORTIFY;FILE" >> "${lCSV_LOG}"
+    echo "RELRO;STACK CANARY;NX;PIE;RPATH;RUNPATH;Symbols;FORTIFY;Fortified;Fortifiable;FILE" >> "${lCSV_LOG}"
     printf "\t%-13.13s  %-16.16s  %-11.11s  %-11.11s  %-11.11s  %-11.11s  %-11.11s  %-5.5s  %s\n" \
       "RELRO" "CANARY" "NX" "PIE" "RPATH" "RUNPATH" "SYMBOLS" "FORTIFY" "FILE" | tee -a "${TMP_DIR}"/s12.tmp
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix: Checksec delivers in total 11 fields, in the final report the fields "Fortified" and " Fortifiable" are left out. In the CSV file that is exported they are included, but the CSV header for those 2 items were missing - added.


* **What is the current behavior?** (You can also link to an open issue here)
The two CSV header fields are missing


* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**
Adding two Header fields


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
-