### PR TITLE
fix: allow specifying multiple installer arguments

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -93,7 +93,7 @@ echo -e "==> ""${GREEN}""Imported ""${INSTALLER_COUNT}"" installer module files"
 echo ""
 
 # expect the user to provide at least one argument
-if [[ "$#" -lt 1 ]] ; then
+if [[ "$#" -lt 1 ]]; then
   echo -e "${RED}""${BOLD}""Invalid number of arguments""${NC}"
   echo -e "\n\n------------------------------------------------------------------"
   echo -e "If you are going to install EMBA in default mode you can use:"
@@ -163,7 +163,7 @@ while getopts CdDfFghlrsc: OPT ; do
 done
 
 # make sure the argument combination passed results in a valid install operation
-if [[ ! ("${LIST_DEP}" -eq 1 || "${DOCKER_SETUP}" -eq 1 || "${FULL}" -eq 1 || "${REMOVE}" -eq 1 || "${IN_DOCKER}" -eq 1) ]] ; then
+if [[ ! ("${LIST_DEP}" -eq 1 || "${DOCKER_SETUP}" -eq 1 || "${FULL}" -eq 1 || "${REMOVE}" -eq 1 || "${IN_DOCKER}" -eq 1) ]]; then
   echo -e "${RED}""${BOLD}""Missing operation""${NC}"
   echo -e "\n\n------------------------------------------------------------------"
   echo -e "If you are going to install EMBA in default mode you can use:"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This is a fix for the installation script which currently fails when called with more than one parameter.


* **What is the current behavior?** (You can also link to an open issue here)
Fixes #1916 


* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**
The installer will now accept any number and any style of arguments as supported by `getopts`.
The minimum number of arguments remains set to 1.
A new check has been introduced after argument parsing that checks for presence of a flag set by any of the standalone operations:
  - `-l`
  - `-d`
  - `-F`
  - `-r`
  - `-D`


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
This PR should not have any functional impact besides the installer.


* **Other information**:
