### PR TITLE
fix: ext filesystem mounting script logic

### DIFF
--- a/modules/P14_ext_mounter.sh
+++ b/modules/P14_ext_mounter.sh
@@ -61,7 +61,7 @@ ext_extractor() {
     return
   }
   if mount | grep -q ext_mount; then
-    if [[ -n "$(find "${lTMP_EXT_MOUNT}" -mindepth 1 -print -quit)" ]]; then
+    if [[ -z "$(find "${lTMP_EXT_MOUNT}" -mindepth 1 -print -quit)" ]]; then
       print_output "[*] No mounted files found in ${ORANGE}${lTMP_EXT_MOUNT}${NC} -> return now"
       return
     fi


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix. 

* **What is the current behavior?** (You can also link to an open issue here)

The current logic in P14_ext_mounter checks if a file is found (if the length of the string from `find "${lTMP_EXT_MOUNT}" -mindepth 1 -print -quit` is **non-zero**) and returns "[*] No mounted files..." 

* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

The new logic in P14_ext_mounter checks if a file is found (if the length of the string from `find "${lTMP_EXT_MOUNT}" -mindepth 1 -print -quit` is **zero**) and returns "[*] No mounted files..." properly. This allows EMBA to further analyze binaries within mounted directories using modules such as S12_binary_protection.

Reference: https://www.gnu.org/software/bash/manual/bash.html.