### PR TITLE
docs update: fixed second level  headings; UTF-8 support

### DIFF
--- a/modules/P07_windows_exe_extract.sh
+++ b/modules/P07_windows_exe_extract.sh
@@ -19,18 +19,20 @@
 : <<'END_OF_DOCS'
 =pod
 
+=encoding UTF-8
+
 =head1 P07_windows_exe_extract
 
-==head2 P07_windows_exe_extract Short description
+=head2 P07_windows_exe_extract Short description
 
 This module extracts Windows executables with 7z.
 
-==head2 P07_windows_exe_extract Detailed description
+=head2 P07_windows_exe_extract Detailed description
 
 Please write a longer description of your module. This should also include further references and links
 that were used.
 
-==head2 P07_windows_exe_extract 3rd party tools
+=head2 P07_windows_exe_extract 3rd party tools
 
 Any 3rd party tool that is needed from your module. Also include the tested and known working
 version and download link:
@@ -41,11 +43,11 @@ version and download link:
 ii  7zip                      23.01+dfsg-8                    amd64        7-Zip file archiver with a high compression ratio
 ii  p7zip-full                16.02+transitional.1            all          transitional package
 
-==head2 P07_windows_exe_extract Testfirmware
+=head2 P07_windows_exe_extract Testfirmware
 
 Most Windows exe files should work fine.
 
-==head2 P07_windows_exe_extract Output
+=head2 P07_windows_exe_extract Output
 
 7-Zip 24.08 (x64) : Copyright (c) 1999-2024 Igor Pavlov : 2024-08-11
  64-bit locale=C.UTF-8 Threads:128 OPEN_MAX:1048576
@@ -88,13 +90,13 @@ Compressed: 1974272
 
 [*] Extracted 32 files and 1 directories from the Windows executable.
 
-==head2 P07_windows_exe_extract License
+=head2 P07_windows_exe_extract License
 
 EMBA module P07_windows_exe_extract is licensed under GPLv3
 SPDX-License-Identifier: GPL-3.0-only
 Link to license document: https://github.com/e-m-b-a/emba/blob/master/LICENSE
 
-==head2 P07_windows_exe_extract Todo
+=head2 P07_windows_exe_extract Todo
 
 This module is in very early state and is currently only able to extract exe files that are provided via the -f switch
 to an EMBA analysis process.
@@ -103,11 +105,11 @@ approach.
 Additionally, we need to walk through the extracted content if we can extract further exe files. This could be also done
 via the deep extractor.
 
-==head2 P07_windows_exe_extract Known issues
+=head2 P07_windows_exe_extract Known issues
 
 See Todo section.
 
-==head2 P07_windows_exe_extract Author(s)
+=head2 P07_windows_exe_extract Author(s)
 
 Michael Messner
 

--- a/modules/S04_windows_basic_analysis.sh
+++ b/modules/S04_windows_basic_analysis.sh
@@ -19,13 +19,15 @@
 : <<'END_OF_DOCS'
 =pod
 
+=encoding UTF-8
+
 =head1 S04_windows_basic_analysis
 
-==head2 S04_windows_basic_analysis Short description
+=head2 S04_windows_basic_analysis Short description
 
 This module uses exiftool and readpe to access pe details details of Windows binaries.
 
-==head2 S04_windows_basic_analysis Detailed description
+=head2 S04_windows_basic_analysis Detailed description
 
 Module starts exiftool without further parameters and writes output to LOG_PATH_MODULE/$(basename $BIN).txt
 
@@ -77,7 +79,7 @@ Product Version                 : 1, 3, 6, 0
 Special Build                   :
 Tag 080904b 0                   :
 
-==head2 S04_windows_basic_analysis 3rd party tools
+=head2 S04_windows_basic_analysis 3rd party tools
 
 Any 3rd party tool that is needed from your module. Also include the tested and known working
 version and download link:
@@ -89,29 +91,29 @@ ii  libimage-exiftool-perl     12.76+dfsg-1        all       library and program
 
 ii  readpe                     0.84-1              amd64     command-line tools to manipulate Windows PE files
 
-==head2 S04_windows_basic_analysis Testfirmware
+=head2 S04_windows_basic_analysis Testfirmware
 
 Any Windows binary (exe) file should be fine.
 
-==head2 S04_windows_basic_analysis Output
+=head2 S04_windows_basic_analysis Output
 
 Example output of module see "Detailed description"
 
-==head2 S04_windows_basic_analysis License
+=head2 S04_windows_basic_analysis License
 
 EMBA module S04_windows_basic_analysis is licensed under GPLv3
 SPDX-License-Identifier: GPL-3.0-only
 Link to license document: https://github.com/e-m-b-a/emba/blob/master/LICENSE
 
-==head2 S04_windows_basic_analysis Todo
+=head2 S04_windows_basic_analysis Todo
 
 None
 
-==head2 S04_windows_basic_analysis Known issues
+=head2 S04_windows_basic_analysis Known issues
 
 None
 
-==head2 S04_windows_basic_analysis Author(s)
+=head2 S04_windows_basic_analysis Author(s)
 
 Michael Messner
 

--- a/modules/S04_windows_basic_analysis.sh
+++ b/modules/S04_windows_basic_analysis.sh
@@ -25,7 +25,7 @@
 
 =head2 S04_windows_basic_analysis Short description
 
-This module uses exiftool and readpe to access pe details details of Windows binaries.
+This module uses exiftool and readpe to access PE details of Windows binaries.
 
 =head2 S04_windows_basic_analysis Detailed description
 

--- a/modules/template_module.sh
+++ b/modules/template_module.sh
@@ -33,23 +33,25 @@
 : <<'END_OF_DOCS'
 =pod
 
+=encoding UTF-8
+
 =head1 MODULE_NAME
 
-==head2 MODULE_NAME Short description
+=head2 MODULE_NAME Short description
 
 Please write a short description of your module. Usually ~2-3 sentences are fine to get an idea.
 
-==head2 MODULE_NAME Detailed description
+=head2 MODULE_NAME Detailed description
 
 Please write a longer description of your module. This should also include further references and links
 that were used.
 
-==head2 MODULE_NAME 3rd party tools
+=head2 MODULE_NAME 3rd party tools
 
 Any 3rd party tool that is needed from your module. Also include the tested and known working version and
 download link.
 
-==head2 MODULE_NAME Testfirmware
+=head2 MODULE_NAME Testfirmware
 
 For verification of the module we need some testfirmware.
 
@@ -59,26 +61,26 @@ Testfirmware details:
 - Checksum (MD5/SHA1/SHA256):
 - Download Link:
 
-==head2 MODULE_NAME Output
+=head2 MODULE_NAME Output
 
 Example output of module
 
-==head2 MODULE_NAME License
+=head2 MODULE_NAME License
 
 EMBA module MODULE_NAME is licensed under GPLv3
 SPDX-License-Identifier: GPL-3.0-only
 Link to license document: https://github.com/e-m-b-a/emba/blob/master/LICENSE
 Note: Only GPL-3.0 will be accepted in the master EMBA repository
 
-==head2 MODULE_NAME Todo
+=head2 MODULE_NAME Todo
 
 Missing stuff that we need to consider.
 
-==head2 MODULE_NAME Known issues
+=head2 MODULE_NAME Known issues
 
 Any known issues or known limitations.
 
-==head2 MODULE_NAME Author(s)
+=head2 MODULE_NAME Author(s)
 
 Michael Messner, Pascal Eckmann
 Note: List all authors including contributors to this module


### PR DESCRIPTION

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
The second level headings in the pod docs now display correctly as second level headings.
Additionally as the docs include UTF-8 sometimes due to copied terminal output I added UTF-8 support via `=encoding UTF-8`. This basically only suppresses the UT-8 warning, because pod would just assume UTF-8 when it detects a Non-ASCII character, but it gives a clean output now.


* **What is the current behavior?** (You can also link to an open issue here)
Second level headings did not render correctly, see #1975 :

```
$ pod2text S04_windows_basic_analysis.sh
S04_windows_basic_analysis
    ==head2 S04_windows_basic_analysis Short description
```

And there was an UTF-8 warning:

```
Wide character in printf at /usr/share/perl/5.34/Pod/Simple.pm line 573.
S04_windows_basic_analysis.sh around line 32: Non-ASCII character seen before =encoding in '└─$'. Assuming UTF-8
```
* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

Correct headings and no UTF-8 warnings:

```
$ pod2text S04_windows_basic_analysis.sh
S04_windows_basic_analysis
  S04_windows_basic_analysis Short description
    This module uses exiftool and readpe to access pe details details of
    Windows binaries.

  S04_windows_basic_analysis Detailed description
    Module starts exiftool without further parameters and writes output to
    LOG_PATH_MODULE/$(basename $BIN).txt

    └─$ exiftool ./vncviewer.exe ExifTool Version Number : 12.76 File Name :
```

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No, unless someone parsed the doc expecting two `==` for second level heading


* **Other information**:
