### PR TITLE
Add P26 S-Record extractor module and srecord dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # nosemgrep
   emba:
-    image: embeddedanalyzer/emba:2.0.1a
+    image: embeddedanalyzer/emba:2.0.1b
     container_name: emba
     read_only: false
     # all pre-checker mount modules need privileged mode
@@ -54,7 +54,7 @@ services:
         soft: 0
 
   emba_quest:
-    image: embeddedanalyzer/emba:2.0.1a
+    image: embeddedanalyzer/emba:2.0.1b
     container_name: emba_quest
     read_only: true
     tmpfs:

--- a/installer/IP00_extractors.sh
+++ b/installer/IP00_extractors.sh
@@ -36,6 +36,8 @@ IP00_extractors() {
     print_pip_info "python-lzo"
     # vmdk extractor:
     print_tool_info "guestfs-tools" 1
+    # srecord converter
+    print_tool_info "srecord" 1
     # payload_dumper:
     print_pip_info "fsspec"
     # Buffalo decryptor

--- a/modules/P02_firmware_bin_file_check.sh
+++ b/modules/P02_firmware_bin_file_check.sh
@@ -123,6 +123,7 @@ set_p02_default_exports() {
   export BMC_ENC_DETECTED=0
   export UBI_IMAGE=0
   export OPENSSL_ENC_DETECTED=0
+  export SREC_DETECTED=0
   export ENGENIUS_ENC_DETECTED=0
   export BUFFALO_ENC_DETECTED=0
   export QNAP_ENC_DETECTED=0
@@ -424,6 +425,12 @@ fw_bin_detector() {
     lUEFI_CHECK=0
     write_csv_log "OpenSSL encrypted" "yes" "NA"
   fi
+  if [[ "${lFILE_BIN_OUT}" == *"Motorola S-Record"* ]]; then
+    print_output "[+] Identified Motorola S-Record firmware - using S-Record extraction module"
+    export SREC_DETECTED=1
+    lUEFI_CHECK=0
+    write_csv_log "Motorola S-Record" "yes" "NA"
+  fi
   # This check is currently only tested on one firmware - further tests needed:
   if [[ "${lHEX_FIRST_LINE}" =~ 00000000\ \ 62\ 67\ 6e\ 00\ 00\ 00\ 00\ 00\ \ 00\ 00\ 00\  ]]; then
     print_output "[+] Identified Buffalo encrpyted firmware - using Buffalo extraction module"
@@ -468,6 +475,7 @@ backup_p02_vars() {
   backup_var "GPG_COMPRESS" "${GPG_COMPRESS}"
   backup_var "ANDROID_OTA" "${ANDROID_OTA}"
   backup_var "OPENSSL_ENC_DETECTED" "${OPENSSL_ENC_DETECTED}"
+  backup_var "SREC_DETECTED" "${SREC_DETECTED}"
   backup_var "BUFFALO_ENC_DETECTED" "${BUFFALO_ENC_DETECTED}"
   backup_var "ZYXEL_ZIP" "${ZYXEL_ZIP}"
   backup_var "QCOW_DETECTED" "${QCOW_DETECTED}"

--- a/modules/P26_srec_extractor.sh
+++ b/modules/P26_srec_extractor.sh
@@ -1,0 +1,93 @@
+#!/bin/bash -p
+
+# EMBA - EMBEDDED LINUX ANALYZER
+#
+# Copyright 2020-2026 Siemens Energy AG
+#
+# EMBA comes with ABSOLUTELY NO WARRANTY. This is free software, and you are
+# welcome to redistribute it under the terms of the GNU General Public License.
+# See LICENSE file for usage of this software.
+#
+# EMBA is licensed under GPLv3
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# Author(s): Atharva Bobde
+#
+
+# Description: Extracts Motorola S-Record firmwares and converts them into binary
+export PRE_THREAD_ENA=0
+
+P26_srec_extractor() {
+  local lNEG_LOG=0
+
+  # detect
+  if [[ "${SREC_DETECTED:-0}" -ne 1 ]]; then
+    return
+  fi
+
+  module_log_init "${FUNCNAME[0]}"
+  module_title "Motorola S-Record firmware extractor"
+  pre_module_reporter "${FUNCNAME[0]}"
+
+  if ! command -v srec_cat >/dev/null; then
+    print_output "[-] S-Record firmware detected, but srec_cat is not installed. Skipping S-Record conversion."
+    module_end_log "${FUNCNAME[0]}" "${lNEG_LOG}"
+    return
+  fi
+  if ! command -v srec_info >/dev/null; then
+    print_output "[-] S-Record firmware detected, but srec_info is not installed. Skipping S-Record conversion."
+    module_end_log "${FUNCNAME[0]}" "${lNEG_LOG}"
+    return
+  fi
+
+  local lFIRMWARE_BN=""
+  lFIRMWARE_BN=$(basename "${FIRMWARE_PATH}")
+  local lEXTRACTION_FILE="${LOG_DIR}/firmware/${lFIRMWARE_BN}.bin"
+
+  srec_firmware_extractor "${FIRMWARE_PATH}" "${lEXTRACTION_FILE}"
+
+  if [[ -f "${lEXTRACTION_FILE}" ]]; then
+    lNEG_LOG=1
+  fi
+
+  if [[ -s "${P99_CSV_LOG}" ]] && grep -q "^${FUNCNAME[0]};" "${P99_CSV_LOG}"; then
+    lNEG_LOG=1
+  fi
+  module_end_log "${FUNCNAME[0]}" "${lNEG_LOG}"
+}
+
+srec_firmware_extractor() {
+  local lSREC_FILE_PATH_="${1:-}"
+  local lEXTRACTION_FILE_="${2:-}"
+
+  if ! [[ -f "${lSREC_FILE_PATH_}" ]]; then
+    print_output "[-] No S-Record file for extraction provided"
+    return
+  fi
+
+  sub_module_title "S-Record firmware conversion"
+
+  print_output "[*] Inspecting S-Record file"
+  # inspect
+  srec_info "${lSREC_FILE_PATH_}" -Motorola | tee -a "${LOG_FILE}"
+
+  print_output "[*] Converting S-Record file to binary format"
+  # convert
+  rm -f "${lEXTRACTION_FILE_}"
+  if srec_cat "${lSREC_FILE_PATH_}" -Motorola -fill 0xFF -within "${lSREC_FILE_PATH_}" -Motorola -Output "${lEXTRACTION_FILE_}" -Binary && [[ -s "${lEXTRACTION_FILE_}" ]]; then
+    print_output "[+] Extracted S-Record firmware file to ${ORANGE}${lEXTRACTION_FILE_}${NC}"
+
+    # Update the global FIRMWARE_PATH to point to the new binary file so pipeline uses the .bin
+    export FIRMWARE_PATH="${lEXTRACTION_FILE_}"
+    backup_var "FIRMWARE_PATH" "${FIRMWARE_PATH}"
+
+    print_ln
+    print_output "[*] Firmware file details: ${ORANGE}$(file -b "${lEXTRACTION_FILE_}")${NC}"
+
+    # Log to CSV
+    write_csv_log "Extractor module" "Original file" "extracted file/dir" "" "SREC conversion"
+    write_csv_log "S-Record conversion" "${lSREC_FILE_PATH_}" "${lEXTRACTION_FILE_}" "" "NA"
+  else
+    print_output "[-] Extraction of S-Record firmware file failed"
+  fi
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
Currently, EMBA does not support Motorola S-Record text-based firmware formats. Analysis halts because the text record format isn't parsed and converted to raw binary prior to the main extraction pipeline running.
#1899 




* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**

This PR introduces a new pre-checker module (P26_srec_extractor.sh) that specifically handles S-Record firmware preparation:

Detects the "Motorola S-Record" format using file.

Uses srec_info to log the firmware's address spaces and headers directly into EMBA's logs.

Uses srec_cat to correctly extract and convert the ASCII text records into a raw .bin payload.

Dynamically updates FIRMWARE_PATH so the rest of the EMBA pipeline downstream (Binwalk, Unblob, etc.) can seamlessly analyze the extracted binary payload.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
NO


* **Other information**:
