### PR TITLE
fixing the installation error for 7.x.x kernerls issue#2057

### DIFF
--- a/installer/ID1_ubuntu_os.sh
+++ b/installer/ID1_ubuntu_os.sh
@@ -29,7 +29,7 @@ ID1_ubuntu_os() {
     if [[ "${WSL}" -ne 1 ]]; then
       # To using ubi and nandsim with modprobe, the linux-modules-extra package must be installed. (Ubuntu 22.04)
       if apt-cache show "linux-modules-extra-$(uname -r)" &>/dev/null; then
-			print_tool_info "linux-modules-extra-$(uname -r)" 1
+        print_tool_info "linux-modules-extra-$(uname -r)" 1
       else
         echo -e "\\n""${ORANGE}""${BOLD}""linux-modules-extra-$(uname -r) not available - skipping (modules now ship in linux-modules).""${NC}"
       fi

--- a/installer/ID1_ubuntu_os.sh
+++ b/installer/ID1_ubuntu_os.sh
@@ -28,7 +28,11 @@ ID1_ubuntu_os() {
 
     if [[ "${WSL}" -ne 1 ]]; then
       # To using ubi and nandsim with modprobe, the linux-modules-extra package must be installed. (Ubuntu 22.04)
-      print_tool_info "linux-modules-extra-$(uname -r)" 1
+      if apt-cache show "linux-modules-extra-$(uname -r)" &>/dev/null; then
+			print_tool_info "linux-modules-extra-$(uname -r)" 1
+      else
+        echo -e "\\n""${ORANGE}""${BOLD}""linux-modules-extra-$(uname -r) not available - skipping (modules now ship in linux-modules).""${NC}"
+      fi
     fi
 
     # is not available in Ubuntu 24.04 -> need to check on this:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
For the ubuntu with 7.x.x kernels the installation is canceled due to a package not found


* **What is the new behavior (if this is a feature change)? If possible add a screenshot.**
It just checks if the package ( linux-modules-extra ) is there than use the old line other wise it just skips it.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no

* **Other information**:
